### PR TITLE
Use DimensionsMat instead of NrRows / NrColumns

### DIFF
--- a/lib/pkghomalg.gi
+++ b/lib/pkghomalg.gi
@@ -244,7 +244,7 @@ function(complex,modulus)
   
   L := [];
   for i in [ 1 .. Length( M ) ] do
-    L[i] :=[ NrRows(  M[i] ), NrColumns( M[i] ) ];
+    L[i] := DimensionsMat( M[i] );
     L[i][3] := RowRankOfMatrix( M[i] );
     L[i][4] := L[i][2] - L[i][3];
   od;
@@ -365,7 +365,7 @@ function(complex,modulus)
   
   L := [];
   for i in [ 1 .. Length( M ) ] do
-    L[i] :=[ NrRows(  M[i] ), NrColumns( M[i] ) ];
+    L[i] := DimensionsMat( M[i] );
     L[i][3] := RowRankOfMatrix( M[i] );
     L[i][4] := L[i][1] - L[i][3];
   od;


### PR DESCRIPTION
This avoids use of NrColumns, which is specific to Homalg,
but hopefully will in the future be merged with the corresponding
GAP operation, which is called NumberColumns with alias NrCols.