### PR TITLE
Avoid InstallValue where possible

### DIFF
--- a/init.g
+++ b/init.g
@@ -11,13 +11,9 @@
 DeclareInfoClass("InfoSimpcomp");
 SetInfoLevel(InfoSimpcomp,1);
 
-DeclareGlobalVariable("SCIntFunc");
-InstallValue(SCIntFunc,rec());
-MakeReadWriteGlobal("SCIntFunc");
-
-DeclareGlobalVariable("SCSettings");
 DeclareGlobalFunction("SCInfoLevel");
 
+BindGlobal("SCIntFunc",rec());
 
 ReadPackage("simpcomp","lib/propobject.gd");
 ReadPackage("simpcomp","lib/tools.gd");

--- a/read.g
+++ b/read.g
@@ -8,12 +8,11 @@
 ##
 ################################################################################
 
-InstallValue(SCSettings,
+BindGlobal("SCSettings",
 rec(
 BreakOnError:=false,
 MailOnError:=false
 ));
-MakeReadWriteGlobal("SCSettings");
 
 SCIntFunc.Version:="2.1.13";
 
@@ -70,8 +69,6 @@ fi;
 SCSettings.ComplexCounter:=1;
 SCIntFunc.CheckExternalProgramsAvailability();
 ReadPackage("simpcomp", "lib/prophandler.gd");
-
-MakeReadOnlyGlobal("SCIntFunc");
 
 #load global library
 InstallValue(SCLib,SCIntFunc.SCLibGlobalInit());


### PR DESCRIPTION
Also remove superfluous calls to `MakeReadWriteGlobal` and `MakeReadOnlyGlobal`.