### PR TITLE
Fix PackageWWWHome

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -22,7 +22,7 @@ SourceRepository := rec(
     URL := Concatenation( "https://github.com/simpcomp-team/", ~.PackageName ),
 ),
 IssueTrackerURL := Concatenation( ~.SourceRepository.URL, "/issues" ),
-PackageWWWHome  := Concatenation( "https://github.com/simpcomp-team/", ~.PackageName ),
+PackageWWWHome  := Concatenation( "https://simpcomp-team.github.io/", ~.PackageName ),
 README_URL      := Concatenation( ~.PackageWWWHome, "/README.md" ),
 PackageInfoURL  := Concatenation( ~.PackageWWWHome, "/PackageInfo.g" ),
 ArchiveURL      := Concatenation( ~.SourceRepository.URL,


### PR DESCRIPTION
Great it seems releasing 2.1.14 worked!

... except it has a bad `PackageWWWHome` value, which breaks our automated scanning for package updates :-/.

Simple solution: merge this PR, **DON'T CHANGE THE VERSION**, just force a re-release via `./release-gap-package --force` -- since our automatic scans for updates is unable to see the update until I manually insert the correct URL, this is harmless.
