### PR TITLE
Revert makedoc.g changes, add basic .release script

### DIFF
--- a/.release
+++ b/.release
@@ -1,0 +1,7 @@
+#!/bin/sh
+# This file is executed by the `release` script from
+# https://github.com/gap-system/ReleaseTools
+
+rm -rf internals
+
+# TODO: create doc/gapdoc/ directory

--- a/makedoc.g
+++ b/makedoc.g
@@ -4,7 +4,7 @@ fi;
 
 AutoDoc(rec(
     gapdoc := rec(
-        scan_dirs := [Concatenation(GAPInfo.RootPaths[2],"pkg/simpcomp/doc/gapdoc")],
+        scan_dirs := ["doc/gapdoc","lib"],
         LaTeXOptions := rec(
             Options := "11pt",
             LateExtraPreamble :=


### PR DESCRIPTION
The `.release` script is invoked by `release-gap-package` in the directory
that will eventually be turned into a tarball.

Unfortunately it is currently being called *after* `makedoc.g`

Some possibly avenues of resolving this:

1. modify `release-gap-package` to call it before running `makedoc.g`. Actually that was how things were done until [this PR](https://github.com/gap-system/ReleaseTools/pull/85) by @wilfwilson. Perhaps this can be reverted. Or perhaps we need two "hooks", calling scripts both before and after the manual was built...

2. we could add a flag to `release-gap-package` which controls when the `.release` script is called

3. on the short term, you could also just temporarily move the code calling `.release` a  bit up