### PR TITLE
Use CDATA in GAPDoc <Example> elements

### DIFF
--- a/lib/DMT.gi
+++ b/lib/DMT.gi
@@ -23,10 +23,10 @@
 ## The <M>i</M>-th list of each set of lists represents the incidences between
 ## the <M>(i-1)</M>-faces and the <M>i</M>-faces. The faces are given by their 
 ## indices of the face lattice.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(3);;
 ## gap> HD:=SCHasseDiagram(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -227,10 +227,10 @@ end;
 ## the input complex to smaller complexes defined by minimal link and deletion 
 ## operations. See <Cite Key="Engstroem09DiscMorseFuncFourierTrans" /> for 
 ## details.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(3);;
 ## gap> f:=SCMorseEngstroem(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -366,11 +366,11 @@ end;
 ## discrete Morse theory approach: Faces are paired with free co-dimension one 
 ## faces until now free faces remain. Then a critical face is removed at random.
 ## See <Cite Key="Benedetti13RandomDMT" /> for details.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(3);;
 ## gap> f:=SCMorseRandom(c);;
 ## gap> Size(f[2]);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -392,11 +392,11 @@ end);
 ## lexicographic random
 ## discrete Morse theory approach. See <Cite Key="Benedetti13RandomDMT" />, 
 ## <Cite Key="Adiprasito14RDMTII" /> for details.
-## <Example>
+## <Example><![CDATA[
 ## gap> c := SCSurface(3,true);;
 ## gap> f:=SCMorseRandomLex(c);;
 ## gap> Size(f[2]);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -428,11 +428,11 @@ end);
 ## reverse lexicographic random
 ## discrete Morse theory approach. See <Cite Key="Benedetti13RandomDMT" />, 
 ## <Cite Key="Adiprasito14RDMTII" /> for details.
-## <Example>
+## <Example><![CDATA[
 ## gap> c := SCSurface(5,false);;
 ## gap> f:=SCMorseRandomRevLex(c);;
 ## gap> Size(f[2]);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -477,7 +477,7 @@ end;
 ## Employs a greedy collapsing algorithm to collapse the simplicial complex 
 ## <Arg>complex</Arg>. 
 ## See also <Ref Meth="SCCollapseLex" /> and <Ref Meth="SCCollapseRevLex" />.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("T^2"){[1..6]}; 
 ## [ [ 4, "T^2 (VT)" ], [ 5, "T^2 (VT)" ], [ 9, "T^2 (VT)" ], 
 ##   [ 10, "T^2 (VT)" ], [ 17, "T^2 (VT)" ], [ 20, "(T^2)#2" ] ]
@@ -491,7 +491,7 @@ end;
 ## gap> coll:=SCCollapseGreedy(bdsphere);
 ## gap> coll.Facets;                     
 ## [ [ 5 ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -522,7 +522,7 @@ end);
 ## Employs a greedy collapsing algorithm in lexicographical order to collapse 
 ## the simplicial complex <Arg>complex</Arg>. See also 
 ## <Ref Meth="SCCollapseGreedy" /> and <Ref Meth="SCCollapseRevLex" />.
-## <Example>
+## <Example><![CDATA[
 ## gap> s:=SCSurface(1,true);;
 ## gap> s:=SCDifference(s,SC([SCFacets(s)[1]]));;
 ## gap> coll:=SCCollapseGreedy(s);
@@ -532,7 +532,7 @@ end);
 ## gap> coll:=SCCollapseLex(ball);
 ## gap> coll.Facets;                     
 ## [ [ 5 ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -563,7 +563,7 @@ end);
 ## Employs a greedy collapsing algorithm in reverse lexicographical order to 
 ## collapse the simplicial complex <Arg>complex</Arg>. 
 ## See also <Ref Meth="SCCollapseGreedy" /> and <Ref Meth="SCCollapseLex" />.
-## <Example>
+## <Example><![CDATA[
 ## gap> s:=SCSurface(1,true);;
 ## gap> s:=SCDifference(s,SC([SCFacets(s)[1]]));;
 ## gap> coll:=SCCollapseGreedy(s);
@@ -573,7 +573,7 @@ end);
 ## gap> coll:=SCCollapseRevLex(ball);
 ## gap> coll.Facets;                     
 ## [ [ 5 ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -606,11 +606,11 @@ end);
 ## from the dual 1-skeleton followed by a collapsing approach.
 ## <Arg>complex</Arg> needs to be a closed weak pseudomanifold for this to work.
 ## For details of the algorithm, see <Cite Key="Paixao143SphereRec" />.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(3);;
 ## gap> f:=SCMorseUST(c);;
 ## gap> Size(f[2]);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -772,17 +772,17 @@ end);
 ## returned in form of a list containing all Morse vectors sorted by number of 
 ## critical points together with the actual vector of critical points and how 
 ## often they ocurred (see <Cite Key="Benedetti13RandomDMT" /> for details).
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCSeriesTorus(2);;
 ## gap> f:=SCMorseSpec(c,30);
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> c:=SCSeriesHomologySphere(2,3,5);;
 ## gap> f:=SCMorseSpec(c,30,SCMorseRandom);
 ## gap> f:=SCMorseSpec(c,30,SCMorseRandomLex);
 ## gap> f:=SCMorseSpec(c,30,SCMorseRandomRevLex);
 ## gap> f:=SCMorseSpec(c,30,SCMorseUST);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1033,11 +1033,11 @@ end;
 ## <M>[ f, [t_1,...,t_n] ]</M>, where <M>f</M> is the (integer) 
 ## free part of <M>H_i</M> and <M>t_i</M> denotes the torsion parts of 
 ## <M>H_i</M> ordered in weakly increasing size.<P/>
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCSeriesTorus(2);;
 ## gap> f:=SCHomology(c);
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> c := SCSeriesHomologySphere(2,3,5);;
 ## gap> SCHomologyEx(c,SCMorseRandom,SmithNormalFormIntegerMat); time;
 ## gap> c := SCSeriesHomologySphere(2,3,5);;
@@ -1048,7 +1048,7 @@ end;
 ## gap> SCHomologyEx(c,SCMorseEngstroem,SmithNormalFormIntegerMat); time;
 ## gap> c := SCSeriesHomologySphere(2,3,5);;
 ## gap> SCHomologyEx(c,SCMorseUST,SmithNormalFormIntegerMat); time;
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1175,10 +1175,10 @@ end);
 ## is returned in form of a list <M>[ f, [t_1,...,t_n] ]</M>, where <M>f</M> 
 ## is the (integer) free part of <M>H_i</M> and <M>t_i</M> denotes the torsion 
 ## parts of <M>H_i</M> ordered in weakly increasing size.<P/>
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCSeriesTorus(2);;
 ## gap> f:=SCHomology(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1211,12 +1211,12 @@ end);
 ## spanning tree of the dual graph of the underlying complex. If
 ## <Arg>top = false</Arg> the output is a spanning tree of the primal graph 
 ## (i.e., the <M>1</M>-skeleton.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCSurface(1,false);;
 ## gap> HD:=SCHasseDiagram(c);;
 ## gap> stTop:=SCSpanningTreeRandom(HD,true);
 ## gap> stBot:=SCSpanningTreeRandom(HD,false);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1500,12 +1500,12 @@ end;
 ## <Arg>tries</Arg> determines the number of times the algorithm will try to 
 ## find a collapsing sequence. The algorithm is a heuristic method and is 
 ## described in <Cite Key="Paixao143SphereRec" />.
-## <Example>
+## <Example><![CDATA[
 ## gap> rp2:=SCSurface(1,false);;
 ## gap> SCIsSimplyConnectedEx(rp2);
 ## gap> c:=SCBdCyclicPolytope(8,18);;
 ## gap> SCIsSimplyConnectedEx(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1778,12 +1778,12 @@ end);
 ## connected. The algorithm is a heuristic method and is described in 
 ## <Cite Key="Paixao143SphereRec" />. Internally calls 
 ## <Ref Func="SCIsSimplyConnectedEx" />.
-## <Example>
+## <Example><![CDATA[
 ## gap> rp2:=SCSurface(1,false);;
 ## gap> SCIsSimplyConnected(rp2);
 ## gap> c:=SCBdCyclicPolytope(8,18);;
 ## gap> SCIsSimplyConnected(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1824,10 +1824,10 @@ end);
 ##
 ## See <Ref Func="SCBistellarIsManifold" /> for an alternative method for 
 ## manifold verification.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdCyclicPolytope(4,20);;
 ## gap> SCIsManifold(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2026,10 +2026,10 @@ end);
 ## The algorithm is a heuristic method and is described in 
 ## <Cite Key="Paixao143SphereRec" /> in more detail.
 ## Internally calls <Ref Func="SCIsManifoldEx" />.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdCyclicPolytope(4,20);;
 ## gap> SCIsManifold(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2065,12 +2065,12 @@ end);
 ## is a standard PL sphere. The function calls 
 ## <Ref Meth="SCIsSimplyConnected" /> which uses
 ## a heuristic method described in <Cite Key="Paixao143SphereRec" />.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdCyclicPolytope(4,20);;
 ## gap> SCIsSphere(c);
 ## gap> c:=SCSurface(1,true);;
 ## gap> SCIsSphere(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>

--- a/lib/bistellar.gi
+++ b/lib/bistellar.gi
@@ -46,7 +46,7 @@
 ## <Item><C>MaxIntervalRandomize := 50</C>: number of flips performed to create 
 ## a randomized sphere. Default: <M>50</M></Item>
 ## </Enum>
-## <Example>
+## <Example><![CDATA[
 ## gap> SCBistellarOptions.BaseRelaxation;
 ## 3
 ## gap> SCBistellarOptions.BaseHeating;
@@ -69,7 +69,7 @@
 ## 5000
 ## gap> SCBistellarOptions.MaxIntervalRandomize;
 ## 50
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -554,17 +554,17 @@ end;
 ## Checks if a simplicial complex <Arg>complex</Arg> can be modified by 
 ## bistellar moves, i. e. if it is a pure simplicial complex which fulfills 
 ## the weak pseudomanifold property with empty boundary.<P/>
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdCrossPolytope(3);;
 ## gap> SCIsMovableComplex(c);
 ## true
-## </Example>
+## ]]></Example>
 ## Complex with non-empty boundary:
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SC([[1,2],[2,3],[3,4],[3,1]]);;
 ## gap> SCIsMovableComplex(c);
 ## false
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -632,14 +632,14 @@ end);
 ## them by the <M>(r+1)</M> faces obtained by uniting <M>m_2</M> with any 
 ## subset of <M>m_1</M> of order <M>r</M>.<P/>
 ## The resulting complex is PL-homeomorphic to <Arg>complex</Arg>. 
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdCrossPolytope(3);;
 ## gap> moves:=SCRMoves(c,1);
 ## [ [ [ 1, 3 ], [ 5, 6 ] ], [ [ 1, 4 ], [ 5, 6 ] ], [ [ 1, 5 ], [ 3, 4 ] ], 
 ##   [ [ 1, 6 ], [ 3, 4 ] ], [ [ 2, 3 ], [ 5, 6 ] ], [ [ 2, 4 ], [ 5, 6 ] ], 
 ##   [ [ 2, 5 ], [ 3, 4 ] ], [ [ 2, 6 ], [ 3, 4 ] ], [ [ 3, 5 ], [ 1, 2 ] ], 
 ##   [ [ 3, 6 ], [ 1, 2 ] ], [ [ 4, 5 ], [ 1, 2 ] ], [ [ 4, 6 ], [ 1, 2 ] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -704,7 +704,7 @@ end);
 ## otherwise.</Returns>
 ## <Description>
 ## See <Ref Meth="SCRMoves"/> for further information.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdCrossPolytope(3);;
 ## gap> moves:=SCMoves(c);
 ## [
@@ -720,7 +720,7 @@ end);
 ## # 2-moves
 ##   [] 
 ##]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -772,7 +772,7 @@ end);
 ## detailed information about bistellar <M>r</M>-moves.<P/>
 ## Note: <Arg>move</Arg> and <Arg>c</Arg> should be given in standard 
 ## labeling to ensure a correct result.
-## <Example>
+## <Example><![CDATA[
 ## gap> obj:=SC([[1,2],[2,3],[3,4],[4,1]]);
 ## gap> moves:=SCMoves(obj);
 ## [[[[1, 2], []], [[1, 4], []], 
@@ -780,7 +780,7 @@ end);
 ##   [[[1], [2, 4]], [[2], [1, 3]], 
 ##     [[3], [2, 4]], [[4], [1, 3]]]]
 ## gap> obj:=SCMove(obj,last[2][1]);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1095,10 +1095,10 @@ end;
 ## <Description>
 ## Computes the face lattice, the <M>f</M>-vector, the AS-determinant, the 
 ## dimension and the maximal vertex label of <Arg>complex</Arg>.
-## <Example>
+## <Example><![CDATA[
 ## gap> obj:=SC([[1,2],[2,3],[3,4],[4,5],[5,6],[6,1]]);
 ## gap> SCExamineComplexBistellar(obj);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1184,7 +1184,7 @@ end);
 ## Please see <Ref Func="SCMailIsPending"/> for further information about the 
 ## email notification system in case <C>SCBistellarOptions.WriteLevel</C> is 
 ## set to <M>2</M>.<P/>
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdCrossPolytope(4);;
 ## gap> SCBistellarOptions.WriteLevel:=0;; # do not save complexes                      
 ## gap> SCReduceComplexEx(c,SCEmpty(),0,SCIntFunc.SCChooseMove);
@@ -1194,9 +1194,9 @@ end);
 ## gap> SCMailIsEnabled();                     
 ## true
 ## gap> SCReduceComplexEx(c,SCEmpty(),0,SCIntFunc.SCChooseMove);
-## </Example>
+## ]]></Example>
 ## Content of sent mail:
-## <Example> NOEXECUTE
+## <Example><![CDATA[ NOEXECUTE
 ## Greetings master,
 ## 
 ## this is simpcomp 0.0.0 running on comp01.maths.fancytown.edu
@@ -1231,7 +1231,7 @@ end);
 ## ##### END MESSAGE #####
 ## 
 ## That's all, I hope this is good news! Have a nice day.
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1551,7 +1551,7 @@ end);
 ## pseudomanifold property via bistellar moves. 
 ## Internally calls <Ref Func="SCReduceComplexEx" Style="Text" />
 ## <C>(complex,SCEmpty(),0,SCIntFunc.SCChooseMove);</C>
-## <Example>
+## <Example><![CDATA[
 ## gap> obj:=SC([[1,2],[2,3],[3,4],[4,5],[5,6],[6,1]]);; # hexagon
 ## gap> SCBistellarOptions.WriteLevel:=0;; # do not save complexes                      
 ## gap> tmp := SCReduceComplex(obj);
@@ -1562,7 +1562,7 @@ end);
 ## #I  round 2, move: [ [ 3 ], [ 2, 5 ] ]
 ## [ 3, 3 ]
 ## #I  SCReduceComplexEx: computed locally minimal complex after 3 rounds.
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1593,7 +1593,7 @@ end);
 ## the check if possible.<P/>
 ## Internally calls <Ref Func="SCReduceComplexEx" Style="Text"/>
 ## <C>(complex1,complex2,1,SCIntFunc.SCChooseMove);</C>
-## <Example>
+## <Example><![CDATA[
 ## gap> SCBistellarOptions.WriteLevel:=0;; # do not save complexes to disk
 ## gap> obj:=SC([[1,2],[2,3],[3,4],[4,5],[5,6],[6,1]]);; # hexagon
 ## gap> refObj:=SCBdSimplex(2);; # triangle as a (minimal) reference object
@@ -1603,7 +1603,7 @@ end);
 ## #I  round 2: [ 3, 3 ]
 ## #I  SCReduceComplexEx: complexes are bistellarly equivalent.
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1690,14 +1690,14 @@ end);
 ## <P/>
 ## Internally calls <Ref Func="SCReduceComplexEx" Style="Text"  />
 ## <C>(complex1,complex2,2,SCIntFunc.SCChooseMove);</C>
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCFromFacets([[1,3],[3,5],[4,5],[4,1]]);;
 ## gap> SCBistellarOptions.WriteLevel:=0;; # do not save any complexes                      
 ## gap> SCReduceAsSubcomplex(c,SCBdCrossPolytope(3));
 ## #I  round 0, move: [ [ 2 ], [ 1, 4 ] ]
 ## [ 3, 3 ]
 ## #I  SCReduceComplexEx: computed locally minimal complex after 1 rounds.
-##</Example>
+##]]></Example>
 ##</Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1734,7 +1734,7 @@ end);
 ##
 ## See <Ref Func="SCIsManifoldEx" /> and <Ref Func="SCIsManifold" /> for 
 ## alternative methods for manifold verification.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdCrossPolytope(3);;
 ## gap> SCBistellarIsManifold(c);
 ## #I  SCBistellarIsManifold: processing vertex link 1/6
@@ -1747,7 +1747,7 @@ end);
 ## #I  SCReduceComplexEx: computed locally minimal complex after 1 rounds.
 ## #I  SCBistellarIsManifold: link is sphere.
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1903,7 +1903,7 @@ end);
 ## where <M>S</M> denotes the simplicial complex passed in 
 ## <Arg>complex</Arg>.<P/>   
 ## Internally calls <Ref Func="SCReduceComplexEx" Style="Text" />.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("S^4~S^1");;
 ## gap> c:=SCLib.Load(last[1][1]);;
 ## gap> l:=SCLink(c,1);
@@ -1917,7 +1917,7 @@ end);
 ## #I  round 5: [ 6, 15, 20, 15, 6 ]
 ## #I  SCReduceComplexEx: computed locally minimal complex after 6 rounds.
 ## 1
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2107,11 +2107,11 @@ end);
 ## <C>SCBistellarOptions.MaxIntervalRandomize</C> (this value is used, if 
 ## <Arg>rounds</Arg> is not specified).       
 ## Internally calls <Ref Func="SCReduceComplexEx" Style="Text" />.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCRandomize(SCBdSimplex(4));
 ## gap> c.F;
 ## [ 20, 85, 130, 65 ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>

--- a/lib/blowups.gi
+++ b/lib/blowups.gi
@@ -505,13 +505,13 @@ end;
 ## Thus, the orientation of the blowup has to be checked in order to verify 
 ## which type of blowup was performed. Normally, repeated computation results 
 ## in both versions.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("Kummer variety");
 ## [ [ 519, "4-dimensional Kummer variety (VT)" ] ]
 ## gap> c:=SCLib.Load(last[1][1]);;                
 ## gap> d:= SCBlowup(c,1);
-## </Example>
-## <Example> NOEXECUTE
+## ]]></Example>
+## <Example><![CDATA[ NOEXECUTE
 ## gap> # resolving the singularities of a 4 dimensional Kummer variety
 ## gap> SCLib.SearchByName("Kummer variety");
 ## [ [ 519, "4-dimensional Kummer variety (VT)" ] ]
@@ -528,7 +528,7 @@ end;
 ## true
 ## gap> d.Homology;
 ## [ [ 0, [ ] ], [ 0, [ ] ], [ 22, [ ] ], [ 0, [ ] ], [ 1, [ ] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -811,14 +811,14 @@ end);
 ## cylinder for a simplicial blowup, compare 
 ## <Cite Key="Spreer09CombPorpsOfK3"/>) with boundary 
 ## <M>L(</M><C>k</C><M>,1)</M>.
-## <Example>
+## <Example><![CDATA[
 ## gap> mapCyl:=SCMappingCylinder(3);;
 ## gap> mapCyl.Homology;              
 ## [ [ 0, [  ] ], [ 0, [  ] ], [ 1, [  ] ], [ 0, [  ] ], [ 0, [  ] ] ]
 ## gap> l31:=SCBoundary(mapCyl);;
 ## gap> l31.Homology;
 ## [ [ 0, [  ] ], [ 0, [ 3 ] ], [ 0, [  ] ], [ 1, [  ] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>

--- a/lib/class3mflds.gi
+++ b/lib/class3mflds.gi
@@ -12,9 +12,9 @@
 ## See <Cite Key="Spreer11CyclicCombMflds"/> for more about the classification 
 ## of combinatorial 3-manifolds with transitive cyclic symmetry up to 
 ## <M>22</M> vertices.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCNrCyclic3Mflds(22);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -49,9 +49,9 @@ end);
 ## See <Cite Key="Spreer11CyclicCombMflds"/> for more about the classification 
 ## of combinatorial 3-manifolds with transitive cyclic symmetry up to 
 ## <M>22</M> vertices.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCCyclic3MfldTopTypes(19);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -6681,9 +6681,9 @@ end;
 ## See <Cite Key="Spreer11CyclicCombMflds"/> for more about the classification 
 ## of combinatorial 3-manifolds with transitive cyclic symmetry up to 
 ## <M>22</M> vertices.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCCyclic3Mfld(15,34);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -6707,9 +6707,9 @@ end);
 ## See <Cite Key="Spreer11CyclicCombMflds"/> for more about the classification 
 ## of combinatorial 3-manifolds with transitive cyclic symmetry up to 
 ## <M>22</M> vertices.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCCyclic3MfldByType("T^3");
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -6739,9 +6739,9 @@ end);
 ## See <Cite Key="Spreer11CyclicCombMflds"/> for more about the 
 ## classification of combinatorial 3-manifolds with transitive cyclic 
 ## symmetry up to <M>22</M> vertices.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCCyclic3MfldListOfGivenType("Sigma(2,3,7)");
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>

--- a/lib/complex.gd
+++ b/lib/complex.gd
@@ -82,13 +82,13 @@
 ## be calculated, in some cases followed by further arguments of the 
 ## property handler function. An example would be:
 ##
-##<Example>
+##<Example><![CDATA[
 ## gap> c:=SCBdSimplex(3);; # create a SCSimplicialComplex object
 ## gap> SCFVector(c);
 ## [ 4, 6, 4 ]
 ## gap> SCSkel(c,0);
 ## [ [ 1 ], [ 2 ], [ 3 ], [ 4 ] ]
-##</Example>
+##]]></Example>
 ##
 ## Here the functions <C>SCFVector</C> and <C>SCSkel</C> are the property 
 ## handler functions, see Chapter <Ref Chap="chap:prophandler" /> for a 
@@ -101,13 +101,13 @@
 ## oriented method which calls property handlers of a 
 ## <C>SCPolyhedralComplex</C> object indirectly and more conveniently:
 ##
-##<Example>
+##<Example><![CDATA[
 ## gap> c:=SCBdSimplex(3);; # create a SCSimplicialComplex object
 ## gap> c.F;
 ## [ 4, 6, 4 ]
 ## gap> c.Skel(0);
 ## [ [ 1 ], [ 2 ], [ 3 ], [ 4 ] ]
-##</Example>
+##]]></Example>
 ##
 ## Note that the code in this example calculates the same properties as in 
 ## the first example above, but the properties of a 

--- a/lib/complex.gi
+++ b/lib/complex.gi
@@ -18,11 +18,11 @@
 ## Checks if <Arg>object</Arg> is of type <C>SCSimplicialComplex</C>. The 
 ## object type <C>SCSimplicialComplex</C> is derived from the object type 
 ## <C>SCPropertyObject</C>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCEmpty();;
 ## gap> SCIsSimplicialComplex(c);
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -111,13 +111,13 @@ end;
 ## <Description>
 ## The function returns a list of known properties of <Arg>complex</Arg>
 ## an lists some of these properties explicitly.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SC([[1,2,3],[1,2,4],[1,3,4],[2,3,4]]);
 ## gap> Print(SCDetails(c));
 ## gap> c.F;
 ## gap> c.Homology;
 ## gap> Print(SCDetails(c));
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -303,11 +303,11 @@ end;
 ## Positively shifts the vertex labels of <Arg>complex</Arg> (provided that 
 ## all labels satisfy the property <C>IsAdditiveElement</C>) by the amount 
 ## specified in <Arg>value</Arg>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(3)+10;;
 ## gap> c.Facets;
 ## [[11, 12, 13], [11, 12, 14], [11, 13, 14], [12, 13, 14]]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -328,11 +328,11 @@ end);
 ## Negatively shifts the vertex labels of <Arg>complex</Arg> (provided that 
 ## all labels satisfy the property <C>IsAdditiveElement</C>) by the amount 
 ## specified in <Arg>value</Arg>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(3)-1;;
 ## gap> c.Facets;
 ## [[0, 1, 2], [0, 1, 3], [0, 2, 3], [1, 2, 3]]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -354,11 +354,11 @@ end);
 ## Multiplies the vertex labels of <Arg>complex</Arg> (provided that all 
 ## labels satisfy the property <C>IsAdditiveElement</C>) with the integer 
 ## specified in <Arg>value</Arg>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(3)*10;;
 ## gap> c.Facets;
 ## [[10, 20, 30], [10, 20, 40], [10, 30, 40], [20, 30, 40]]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -381,11 +381,11 @@ end);
 ## in <Arg>value</Arg> (provided that all labels satisfy the property 
 ## <C>IsAdditiveElement</C>). Warning: this might result in different vertices 
 ## being assigned the same label or even in invalid facet lists, so be careful.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=(SCBdSimplex(3)*10) mod 7;;
 ## gap> c.Facets;
 ## [[3, 6, 2], [3, 6, 5], [3, 2, 5], [6, 2, 5]]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -408,9 +408,9 @@ end);
 ## <Arg>complex</Arg>, i.e. the <Arg>value</Arg>-fold cartesian product of 
 ## copies of <Arg>complex</Arg>. The complex passed as argument is not altered. 
 ## Internally calls <Ref Func="SCCartesianPower"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(2)^2; #a torus
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -434,7 +434,7 @@ end);
 ## Uses the lexicographically first facets of both complexes to do the gluing. 
 ## The complexes passed as arguments are not altered. Internally calls 
 ## <Ref Func="SCConnectedSum"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("RP^3");;
 ## gap> c:=SCLib.Load(last[1][1]);;
 ## gap> SCLib.SearchByName("S^2~S^1"){[1..3]};
@@ -442,7 +442,7 @@ end);
 ##   [ 27, "S^2~S^1 (VT)" ] ]
 ## gap> d:=SCLib.Load(last[1][1]);;
 ## gap> c:=c+d; #form RP^3#(S^2~S^1)
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -484,11 +484,11 @@ end);
 ## <Description>
 ## Forms the simplicial cartesian product of <Arg>complex1</Arg> and 
 ## <Arg>complex2</Arg>. Internally calls <Ref Func="SCCartesianProduct"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("RP^2");
 ## [ [ 3, "RP^2 (VT)" ], [ 262, "RP^2xS^1" ] ]
 ## gap> c:=SCLib.Load(last[1][1])*SCBdSimplex(3); #form RP^2 x S^2
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -509,13 +509,13 @@ end);
 ## <Description>
 ## Calculates whether two simplicial complexes are isomorphic, i.e. are 
 ## equal up to a relabeling of the vertices.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(3);;
 ## gap> c=c+10;
 ## true
 ## gap> c=SCBdCrossPolytope(4);
 ## false
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -539,9 +539,9 @@ end);
 ## <Description>
 ## Computes the union of two simplicial complexes by calling 
 ## <Ref Func="SCUnion"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=Union(SCBdSimplex(3),SCBdSimplex(3)+3); #a wedge of two 2-spheres
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -565,7 +565,7 @@ end);
 ## <Description>
 ## Computes the ``difference'' of two simplicial complexes by calling 
 ## <Ref Func="SCDifference" />.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(3);;
 ## gap> d:=SC([[1,2,3]]);;
 ## gap> disc:=Difference(c,d);;
@@ -574,7 +574,7 @@ end);
 ## gap> empty:=Difference(d,c);;
 ## gap> empty.Dim;
 ## -1
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -596,14 +596,14 @@ end);
 ## <Description>
 ## Computes the ``intersection'' of two simplicial complexes by calling 
 ## <Ref Func="SCIntersection" />.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(3);;        
 ## gap> d:=SCBdSimplex(3);;        
 ## gap> d:=SCMove(d,[[1,2,3],[]]);;
 ## gap> d:=d+1;;                   
 ## gap> s1.Facets;                 
 ## [ [ 2, 3 ], [ 2, 4 ], [ 3, 4 ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -628,12 +628,12 @@ end);
 ## Makes a copy of <Arg>complex</Arg>. This is actually a ``deep copy'' 
 ## such that all properties of the copy can be altered without changing 
 ## the original complex. Internally calls <Ref Func="SCCopy"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdCrossPolytope(7);;
 ## gap> d:=ShallowCopy(c)+10;;
 ## gap> c.Facets=d.Facets;
 ## false
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -656,18 +656,18 @@ end);
 ## Makes a ``deep copy'' of <Arg>complex</Arg> -- this is a copy such that 
 ## all properties of the copy can be altered without changing the original 
 ## complex.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(4);;
 ## gap> d:=SCCopy(c)-1;;
 ## gap> c.Facets=d.Facets;
 ## false
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(4);;
 ## gap> d:=SCCopy(c);;
 ## gap> IsIdenticalObj(c,d);
 ## false
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -703,7 +703,7 @@ end);
 ## <M>d</M> is the dimension of the complex. <M>d+1</M> is returned instead 
 ## of <M>d</M>, as all lists in &GAP; are indexed beginning with 1 -- thus 
 ## this also holds for all the face lattice related properties of the complex.   
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByAttribute("F=[12,66,108,54]");;
 ## gap> c:=SCLib.Load(last[1][1]);;
 ## gap> for i in [1..Size(c)] do Print(c.F[i],"\n"); od;
@@ -711,7 +711,7 @@ end);
 ## 66
 ## 108
 ## 54
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -739,7 +739,7 @@ end);
 ## <Description>
 ## Returns the ``size'' of a simplicial complex by calling 
 ## <C>Size(</C><Arg>complex</Arg><C>)</C>.   
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByAttribute("F=[12,66,108,54]");;
 ## gap> c:=SCLib.Load(last[1][1]);;
 ## gap> for i in [1..Length(c)] do Print(c.F[i],"\n"); od;
@@ -747,7 +747,7 @@ end);
 ## 66
 ## 108
 ## 54
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -771,7 +771,7 @@ end);
 ## list. If <M>pos \geq d+2</M>, where <M>d</M> is the dimension of 
 ## <Arg>complex</Arg>, the empty set is returned. Note that <Arg>pos</Arg> 
 ## must be <M>\geq 1</M>.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("K^2");
 ## [ [ 18, "K^2 (VT)" ], [ 221, "K^2 (VT)" ] ]
 ## gap> c:=SCLib.Load(last[1][1]);;
@@ -785,7 +785,7 @@ end);
 ##   [ 13, 14 ] ]
 ## gap> c[4];
 ## [  ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -838,14 +838,14 @@ end);
 ## success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Provides an iterator object for the face lattice of a simplicial complex.   
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdCrossPolytope(4);;
 ## gap> for faces in c do Print(Length(faces),"\n"); od;
 ## 8
 ## 24
 ## 32
 ## 16
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -886,13 +886,13 @@ end);
 ## properties (apart from Facets, Dim and Name) dropped, clearing all 
 ## previously computed properties. See also <Ref Meth="SCPropertyDrop" /> 
 ## and <Ref Meth="SCPropertyTmpDrop" />.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SC(SCFacets(SCBdCyclicPolytope(10,12)));
 ## gap> c.F; time;                                 
 ## gap> c.F; time;                                 
 ## gap> c:=SCPropertiesDropped(c);                 
 ## gap> c.F; time;                                 
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>

--- a/lib/fromgroup.gi
+++ b/lib/fromgroup.gi
@@ -40,7 +40,7 @@
 ## by a list of indices of <C>repHigh</C>) which have to be contained in any 
 ## output complex. If <Arg>subset</Arg> is anything else than a subset of 
 ## <C>matrixAllowedRows</C> the argument is ignored.
-## <Example>
+## <Example><![CDATA[
 ## gap> G:=PrimitiveGroup(8,5);
 ## gap> Size(G);
 ## gap> Transitivity(G);
@@ -52,7 +52,7 @@
 ## gap> SCLibDetermineTopologicalType(SCLink(c,1));
 ## gap> # there are no 3-neighborly 3-manifolds with 8 vertices
 ## gap> list:=SCsFromGroupExt(PrimitiveGroup(8,5),8,3,0,0,true,false,0,[]); 
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -953,9 +953,9 @@ end);
 ## <Arg>removeDoubleEntries</Arg> specifies whether the results are checked 
 ## for combinatorial isomorphism, preventing isomorphic entries. Internally 
 ## calls <Ref Func="SCsFromGroupExt" /> for every group.
-## <Example>
+## <Example><![CDATA[
 ## gap> list:=SCsFromGroupByTransitivity(8,3,2,true,true,true);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>

--- a/lib/generate.gi
+++ b/lib/generate.gi
@@ -113,13 +113,13 @@ end;
 ## <Returns>simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Constructs a simplicial complex object from the set of <Arg>generators</Arg> on which the group <Arg>group</Arg> acts, i.e. a complex which has <Arg>group</Arg> as a subgroup of the automorphism group and a facet list that consists of the <Arg>group</Arg>-orbits specified by the list of representatives passed in <Arg>generators</Arg>. Note that <Arg>group</Arg> is not stored as an attribute of the resulting complex as it might just be a subgroup of the actual automorphism group. Internally calls <C>Orbits</C> and <Ref Func="SCFromFacets" />. 
-## <Example>
+## <Example><![CDATA[
 ## gap> #group: AGL(1,7) of order 42
 ## gap> G:=Group([(2,6,5,7,3,4),(1,3,5,7,2,4,6)]);;
 ## gap> c:=SCFromGenerators(G,[[ 1, 2, 4 ]]);
 ## gap> SCLib.DetermineTopologicalType(c);
 ## [ [ true, 5 ] ] # the 7-vertex torus
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -191,10 +191,10 @@ end);
 ## <Description>
 ## Constructs a simplicial complex object from the given facet list. The facet list <Arg>facets</Arg> has to be a duplicate free list (or set) which consists of duplicate free entries, which are in turn lists or sets. For the vertex labels (i. e. the entries of the list items of <Arg>facets</Arg>) an ordering via the less-operator has to be defined. Following Section 4.11 of the &GAP; manual this is the case for objects of the following families: rationals <C>IsRat</C>, cyclotomics <C>IsCyclotomic</C>, finite field elements <C>IsFFE</C>, permutations <C>IsPerm</C>, booleans <C>IsBool</C>, characters <C>IsChar</C> and lists (strings) <C>IsList</C>.<P/>
 ## Internally the vertices are mapped to the standard labeling <M>1..n</M>, where <M>n</M> is the number of vertices of the complex and the vertex labels of the original complex are stored in the property ''VertexLabels'', see <Ref Func="SCLabels" /> and the <C>SCRelabel..</C> functions like <Ref Func="SCRelabel" /> or <Ref Func="SCRelabelStandard" />. 
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCFromFacets([[1,2,5], [1,4,5], [1,4,6], [2,3,5], [3,4,6], [3,5,6]]);
 ## gap> c:=SCFromFacets([["a","b","c"], ["a","b",1], ["a","c",1], ["b","c",1]]);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -252,9 +252,9 @@ end);
 ## <Returns>simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## A shorter function to create a simplicial complex from a facet list, just calls <Ref Func="SCFromFacets" Style="Text"/>(<Arg>facets</Arg>).
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SC(Combinations([1..6],5));
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -274,9 +274,9 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Generates an empty complex (of dimension <M>-1</M>), i. e. a <C>SCSimplicialComplex</C> object with empty facet list.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCEmpty();
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -303,7 +303,7 @@ end);
 ## <Returns> a list of integers of size <C>d + 1</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the <M>f</M>-vector of the <M>d</M>-dimensional cross polytope without generating the underlying complex.  
-## <Example>
+## <Example><![CDATA[
 ## gap> SCFVectorBdCrossPolytope(50);
 ## [100, 4900, 156800, 3684800, 67800320, 1017004800, 12785203200,
 ##   137440934400, 1282782054400, 10518812846080, 76500457062400,
@@ -320,7 +320,7 @@ end);
 ##   878592473867432755200, 279552150776001331200, 74547240206933688320,
 ##   16205921784116019200, 2758454771764428800, 344806846470553600,
 ##   28147497671065600, 1125899906842624]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ## <#/GAPDoc>
@@ -352,7 +352,7 @@ end);
 ## <Returns> a list of integers of size <C>d+1</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the <M>f</M>-vector of the <Arg>d</Arg>-dimensional cyclic polytope on <Arg>n</Arg> vertices, <M>n\geq d+2</M>, without generating the underlying complex.  
-## <Example>
+## <Example><![CDATA[
 ## gap> SCFVectorBdCyclicPolytope(25,198); 
 ## [ 198, 19503, 1274196, 62117055, 2410141734, 77526225777, 2126433621312, 
 ##   50768602708824, 1071781612741840, 20256672480820776, 346204947854027808, 
@@ -361,7 +361,7 @@ end);
 ##   6062663500381642763609, 6294919173643129209180, 4911378208855785427761, 
 ##   2840750019404460890298, 1183225500922302444568, 335951678686835900832, 
 ##   58265626173398052500, 4661250093871844200 ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ## <#/GAPDoc>
@@ -404,7 +404,7 @@ end);
 ## <Returns> a list of integers of size <C>d + 1</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the <M>f</M>-vector of the <M>d</M>-simplex without generating the underlying complex.  
-## <Example>
+## <Example><![CDATA[
 ## gap> SCFVectorBdSimplex(100);
 ## [101, 5050, 166650, 4082925, 79208745, 1267339920, 17199613200,
 ##   202095455100, 2088319702700, 19212541264840, 158940114100040,
@@ -444,7 +444,7 @@ end);
 ##   297525414027312240, 51297485177122800, 8160963550905900, 1192050855750300,
 ##   158940114100040, 19212541264840, 2088319702700, 202095455100, 17199613200,
 ##   1267339920, 79208745, 4082925, 166650, 5050, 101]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -478,9 +478,9 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Generates the boundary of the <M>d</M>-dimensional cross polytope <M>\beta^{d}</M>, a centrally symmetric combinatorial <M>d-1</M>-sphere.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCBdCrossPolytope(3); # the octahedron
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -534,9 +534,9 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Generates the boundary complex of the <Arg>d</Arg>-dimensional cyclic polytope (a combinatorial <M>d-1</M>-sphere) on <Arg>n</Arg> vertices, where <M>n\geq d+2</M>.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCBdCyclicPolytope(3,8); 
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -619,9 +619,9 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Generates the boundary of the <M>d</M>-simplex <M>\Delta^d</M>, a combinatorial <M>d-1</M>-sphere.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCBdSimplex(5);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -677,9 +677,9 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Generates the <Arg>d</Arg>-simplex.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCSimplex(3);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -718,7 +718,7 @@ end);
 ## <Description>
 ## Computes the simplicial cartesian product of <Arg>complex1</Arg> and <Arg>complex2</Arg> where  <Arg>complex1</Arg> and <Arg>complex2</Arg> are pure, simplicial complexes. The original vertex labeling of <Arg>complex1</Arg> and <Arg>complex2</Arg> is changed into the standard one. The new complex has vertex labels of type <M>[v_i, v_j]</M> where <M>v_i</M> is a vertex of <Arg>complex1</Arg> and <M>v_j</M> is a vertex of <Arg>complex2</Arg>.<P/>
 ## If <M>n_i</M>, <M>i=1,2</M>, are the number facets and <M>d_i</M>, <M>i=1,2</M>, are the dimensions of <Arg>complexi</Arg>, then the new complex has <M>n_1 \cdot n_2 \cdot { d_1+d_2 \choose d_1}</M> facets. The number of vertices of the new complex equals the product of the numbers of vertices of the arguments.
-## <Example>
+## <Example><![CDATA[
 ## gap> c1:=SCBdSimplex(2);;
 ## gap> c2:=SCBdSimplex(3);;
 ## gap> c3:=SCCartesianProduct(c1,c2);
@@ -726,7 +726,7 @@ end);
 ## [ [ 0, [  ] ], [ 1, [  ] ], [ 1, [  ] ], [ 1, [  ] ] ]
 ## gap> c3.F;
 ## [ 12, 48, 72, 36 ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -839,7 +839,7 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## The new complex is <M>PL</M>-homeomorphic to <M>n</M> times the cartesian product of <Arg>complex</Arg>, of dimensions <M>n \cdot d</M> and has <M>f_{d}^n \cdot n \cdot \frac{2n-1}{2^{n-1}}!</M> facets where <M>d</M> denotes the dimension and <M>f_d</M> denotes the number of facets of <Arg>complex</Arg>. Note that the complex returned by the function is not the <M>n</M>-fold cartesian product <Arg>complex</Arg><M>^n</M> of <Arg>complex</Arg> (which, in general, is not simplicial) but a simplicial subdivision of <Arg>complex</Arg><M>^n</M>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(2);;
 ## gap> 4torus:=SCCartesianPower(c,4);
 ## gap> 4torus.Homology;
@@ -848,7 +848,7 @@ end);
 ## 0
 ## gap> 4torus.F;
 ## [ 81, 1215, 4050, 4860, 1944 ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -961,7 +961,7 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## In a lexicographic ordering the smallest facet of both <Arg>complex1</Arg> and  <Arg>complex2</Arg> is removed and the complexes are glued together along the resulting boundaries. The bijection used to identify the vertices of the boundaries differs from the one chosen in <Ref Func="SCConnectedSum"/> by a transposition. Thus, the topological type of <C>SCConnectedSumMinus</C> is different from the one of <Ref Func="SCConnectedSum"/> whenever <Arg>complex1</Arg> and <Arg>complex2</Arg> do not allow an orientation reversing homeomorphism. 
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("T^2"){[1..6]};
 ## [ [ 4, "T^2 (VT)" ], [ 5, "T^2 (VT)" ], [ 9, "T^2 (VT)" ], 
 ##   [ 10, "T^2 (VT)" ], [ 17, "T^2 (VT)" ], [ 20, "(T^2)#2" ] ]
@@ -971,8 +971,8 @@ end);
 ## [ [ 0, [  ] ], [ 4, [  ] ], [ 1, [  ] ] ]
 ## gap> genus2.Chi;
 ## -2
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("CP^2");
 ## [ [ 16, "CP^2 (VT)" ], [ 96, "CP^2#-CP^2" ], 
 ##   [ 97, "CP^2#CP^2" ], [ 185, "CP^2#(S^2xS^2)" ], 
@@ -995,7 +995,7 @@ end);
 ## gap> PrintArray(SCIntersectionForm(c2));
 ## [ [   1,   0 ],
 ##   [   0,  -1 ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1129,7 +1129,7 @@ end;
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## In a lexicographic ordering the smallest facet of both <Arg>complex1</Arg> and <Arg>complex2</Arg> is removed and the complexes are glued together along the resulting boundaries. The bijection used to identify the vertices of the boundaries differs from the one chosen in <Ref Func="SCConnectedSumMinus"/> by a transposition. Thus, the topological type of <C>SCConnectedSum</C> is different from the one of <Ref Func="SCConnectedSumMinus"/> whenever <Arg>complex1</Arg> and <Arg>complex2</Arg> do not allow an orientation reversing homeomorphism. 
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("T^2"){[1..6]};
 ## [ [ 4, "T^2 (VT)" ], [ 5, "T^2 (VT)" ], [ 9, "T^2 (VT)" ], 
 ##   [ 10, "T^2 (VT)" ], [ 17, "T^2 (VT)" ], [ 20, "(T^2)#2" ] ]
@@ -1139,8 +1139,8 @@ end;
 ## [ [ 0, [  ] ], [ 4, [  ] ], [ 1, [  ] ] ]
 ## gap> genus2.Chi;
 ## -2
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("CP^2");
 ## [ [ 16, "CP^2 (VT)" ], [ 96, "CP^2#-CP^2" ], 
 ##   [ 97, "CP^2#CP^2" ], [ 185, "CP^2#(S^2xS^2)" ], 
@@ -1163,7 +1163,7 @@ end;
 ## gap> PrintArray(SCIntersectionForm(c2));
 ## [ [   1,   0 ],
 ##   [   0,  -1 ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1260,7 +1260,7 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## If <M>n \geq 2</M>, the function internally calls <M>1 \times</M> <Ref Func="SCConnectedSum"/> and <M>(n-2) \times</M> <Ref Func="SCConnectedSumMinus"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("T^2"){[1..6]};
 ## [ [ 4, "T^2 (VT)" ], [ 5, "T^2 (VT)" ], [ 9, "T^2 (VT)" ], 
 ##   [ 10, "T^2 (VT)" ], [ 17, "T^2 (VT)" ], [ 20, "(T^2)#2" ] ]
@@ -1270,7 +1270,7 @@ end);
 ## -18
 ## gap> genus10.F;
 ## [ 43, 183, 122 ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1359,11 +1359,11 @@ end);
 ## <Description>
 ## <Arg>diffcycle</Arg> induces a simplex <M>\Delta = ( v_1 , \ldots , v_{n+1} )</M> by <M>v_1 = </M><Arg>diffcycle[1]</Arg>, <M>v_i = v_{i-1} + </M> <Arg>diffcycle[i]</Arg> and a cyclic group action by <M>\mathbb{Z}_{\sigma}</M> where <M>\sigma = \sum </M> <Arg>diffcycle[i]</Arg> is the modulus of <C>diffcycle</C>. The function returns the <M>\mathbb{Z}_{\sigma}</M>-orbit of <M>\Delta</M>.<P/>
 ## Note that modulo operations in &GAP; are often a little bit cumbersome, since all integer ranges usually start from <M>1</M>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCDifferenceCycleExpand([1,1,2]);;
 ## gap> c.Facets;
 ## [ [ 1, 2, 3 ], [ 1, 2, 4 ], [ 1, 3, 4 ], [ 2, 3, 4 ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1400,7 +1400,7 @@ end);
 ## Creates a simplicial complex object from the list of difference cycles provided. If <Arg>diffcycles</Arg> is of length <M>1</M> the computation is equivalent to the one in <Ref Func="SCDifferenceCycleExpand"/>. Otherwise the induced modulus (the sum of all entries of a difference cycle) of all cycles has to be equal and the union of all expanded difference cycles is returned.<P/>
 ## A <M>n</M>-dimensional difference cycle <M>D = (d_1 : \ldots : d_{n+1})</M> induces a simplex <M>\Delta = ( v_1 , \ldots , v_{n+1} )</M> by <M>v_1 = d_1</M>, <M>v_i = v_{i-1} + d_i</M> and a cyclic group action by <M>\mathbb{Z}_{\sigma}</M> where <M>\sigma = \sum d_i</M> is the modulus of <M>D</M>. The function returns the <M>\mathbb{Z}_{\sigma}</M>-orbit of <M>\Delta</M>.<P/>
 ## Note that modulo operations in &GAP; are often a little bit cumbersome, since all integer ranges usually start from <M>1</M>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCFromDifferenceCycles([[1,1,6],[2,3,3]]);;
 ## gap> c.F;
 ## [ 8, 24, 16 ]
@@ -1416,7 +1416,7 @@ end);
 ## #I  SCIsManifold: link is sphere.
 ## #I  SCIsManifold: transitive automorphism group, checking only one link.
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1460,7 +1460,7 @@ end);
 ## <Returns> list with possibly duplicate entries upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## A difference cycle is returned, i. e. a list of integer values of length <M>(d+1)</M>, if <M>d</M> is the dimension of <Arg>simplex</Arg>, and a sum equal to <Arg>modulus</Arg>. In some sense this is the inverse operation of <Ref Func="SCDifferenceCycleExpand"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> sphere:=SCBdSimplex(4);;
 ## gap> gens:=SCGenerators(sphere);
 ## [ [ [ 1, 2, 3, 4 ], [ [ 5 ] ] ] ]
@@ -1470,7 +1470,7 @@ end);
 ## gap> c.Facets;
 ## [ [ 1, 2, 3, 4 ], [ 1, 2, 3, 5 ], [ 1, 2, 4, 5 ], [ 1, 3, 4, 5 ],
 ##   [ 2, 3, 4, 5 ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1502,14 +1502,14 @@ end);
 ## <Returns> a list of simplicial complexes of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes all strongly connected components of a pure simplicial complex.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SC([[1,2,3],[2,3,4],[4,5,6],[5,6,7]]);;
 ## gap> comps:=SCStronglyConnectedComponents(c);
 ## gap> comps[1].Facets;
 ## [ [ 1, 2, 3 ], [ 2, 3, 4 ] ]
 ## gap> comps[2].Facets;
 ## [ [ 4, 5, 6 ], [ 5, 6, 7 ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1616,14 +1616,14 @@ end);
 ## <Returns> a list of simplicial complexes of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes all connected components of an arbitrary simplicial complex.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SC([[1,2,3],[3,4,5],[4,5,6,7,8]]);;
 ## gap> SCRename(c,"connected complex");;
 ## gap> SCConnectedComponents(c);
 ## gap> c:=SC([[1,2,3],[4,5],[6,7,8]]);;
 ## gap> SCRename(c,"non-connected complex");;
 ## gap> SCConnectedComponents(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>                                         
@@ -1746,14 +1746,14 @@ end;
 ## <Returns> a permutation group and a list of <M>5</M>-tuples of integers upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## For a given prime <Arg>p</Arg> the automorphism group (AGL<M>(1,p)</M>) and the generators of all members of the series of <M>2</M>-transitive combinatorial <M>4</M>-pseudomanifolds with <Arg>p</Arg> vertices from <Cite Key="Spreer10Diss"/>, Section 5.2, is computed. The affine linear group AGL<M>(1,p)</M> is returned as the first argument. If no member of the series with <Arg>p</Arg> vertices exists only the group is returned. 
-## <Example>
+## <Example><![CDATA[
 ## gap> gens:=SCSeriesAGL(17);
 ## [ AGL(1,17), [ [ 1, 2, 4, 8, 16 ] ] ]
 ## gap> c:=SCFromGenerators(gens[1],gens[2]);;
 ## gap> SCIsManifold(SCLink(c,1));
 ## true
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> List([19..23],x->SCSeriesAGL(x));     
 ## #I  SCSeriesAGL: argument must be a prime > 13.
 ## #I  SCSeriesAGL: argument must be a prime > 13.
@@ -1776,7 +1776,7 @@ end;
 ## [ AGL(1,80071), [  ] ]
 ## gap> SCSeriesAGL(80077);                                                 
 ## [ AGL(1,80077), [ [ 1, 2, 4126, 39302, 40778 ] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1853,14 +1853,14 @@ end);
 ## <Returns> a simplicial complex upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Constructs the complex <M>B(i,d)</M> as described in <Cite Key="Klee11CentSymmMnfFewVert" />, cf. <Cite Key="Effenberger10Diss" />, <Cite Key="Sparla99LBTComb2kMnf" />. The complex <M>B(i,d)</M> is a <M>i</M>-Hamiltonian subcomplex of the <M>d</M>-cross polytope and its boundary topologically is a sphere product <M>S^i\times S^{d-i-2}</M> with vertex transitive automorphism group.   
-## <Example>
+## <Example><![CDATA[
 ## gap> b26:=SCSeriesBid(2,6);
 ## gap> s2s2:=SCBoundary(b26);
 ## gap> SCFVector(s2s2);
 ## gap> SCAutomorphismGroup(s2s2); 
 ## gap> SCIsManifold(s2s2); 
 ## gap> SCHomology(s2s2);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1922,13 +1922,13 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Generates the combinatorial <M>3</M>-manifold <M>C_{2n}</M>, <M>n \geq 8</M>, with <M>2n</M> vertices from <Cite Key="Spreer10Diss"/>, Section 4.5.3 and Section 5.2. The complex is homeomorphic to <M>S^2 \times S^1</M> for <M>n</M> odd and homeomorphic to <M>S^2 \dtimes S^1</M> in case <M>n</M> is an even number. In the latter case <M>C_{2n}</M> is isomorphic to <M>D_{2n}</M> from <Ref Func="SCSeriesD2n"/>. The complexes are believed to appear as the vertex links of some of the members of the series of <M>2</M>-transitive <M>4</M>-pseudomanifolds from <Ref Func="SCSeriesAGL"/>. Internally calls <Ref Func="SCFromDifferenceCycles"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCSeriesC2n(8);
 ## gap> SCGenerators(c);  
 ## [ [ [ 1, 2, 3, 6 ], 32 ], [ [ 1, 2, 5, 6 ], 16 ], [ [ 1, 3, 6, 8 ], 16 ], 
 ##   [ [ 1, 3, 8, 10 ], 16 ] ]
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> c:=SCSeriesC2n(8);;
 ## gap> d:=SCSeriesD2n(8); 
 ## gap> SCIsIsomorphic(c,d);
@@ -1939,7 +1939,7 @@ end);
 ## [ [ 0, [  ] ], [ 1, [  ] ], [ 1, [  ] ], [ 1, [  ] ] ]
 ## gap> d.Homology;
 ## [ [ 0, [  ] ], [ 1, [  ] ], [ 0, [ 2 ] ], [ 0, [  ] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1973,14 +1973,14 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Generates the combinatorial <M>3</M>-manifold <M>D_{2n}</M>, <M>n \geq 8</M>, <M>n \neq 9</M>, with <M>2n</M> vertices from <Cite Key="Spreer10Diss"/>, Section 4.5.3 and Section 5.2. The complex is homeomorphic to <M>S^2 \dtimes S^1</M>. In the case that <M>n</M> is even <M>D_{2n}</M> is isomorphic to <M>C_{2n}</M> from <Ref Func="SCSeriesC2n"/>. The complexes are believed to appear as the vertex links of some of the members of the series of <M>2</M>-transitive <M>4</M>-pseudomanifolds from <Ref Func="SCSeriesAGL"/>. Internally calls <Ref Func="SCFromDifferenceCycles"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> d:=SCSeriesD2n(15);
 ## gap> SCAutomorphismGroup(d);  
 ## TransitiveGroup(30,14) = t30n14
 ## gap> StructureDescription(last);
 ## "D60"
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> c:=SCSeriesC2n(8);;
 ## gap> d:=SCSeriesD2n(8); 
 ## gap> SCIsIsomorphic(c,d);
@@ -1991,7 +1991,7 @@ end);
 ## [ [ 0, [  ] ], [ 1, [  ] ], [ 1, [  ] ], [ 1, [  ] ] ]
 ## gap> d.Homology;
 ## [ [ 0, [  ] ], [ 1, [  ] ], [ 0, [ 2 ] ], [ 0, [  ] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2021,14 +2021,14 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the symmetric orientable sphere bundle Ku<M>(n)</M> with <M>4n</M> vertices from <Cite Key="Spreer10Diss"/>, Section 4.5.2. The series is defined as a generalization of the slicings from <Cite Key="Spreer10Diss"/>, Section 3.3.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCSeriesKu(4);                                    
 ## gap> SCSlicing(c,[[1,2,3,4,9,10,11,12],[5,6,7,8,13,14,15,16]]);
 ## gap> Mminus:=SCSpan(c,[1,2,3,4,9,10,11,12]);;                  
 ## gap> Mplus:=SCSpan(c,[5,6,7,8,13,14,15,16]);;                  
 ## gap> SCCollapseGreedy(Mminus).Facets;
 ## gap> SCCollapseGreedy(Mplus).Facets; 
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2093,14 +2093,14 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## <C>SCSeriesCSTSurface(l,j,2k)</C> generates the centrally symmetric transitive (cst) surface <M>S_{(l,j,2k)}</M>, <C>SCSeriesCSTSurface(l,2k)</C> generates the cst surface <M>S_{(l,2k)}</M> from <Cite Key="Spreer10PartBetaK"/>, Section 4.4.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCSeriesCSTSurface(2,4,14);
 ## gap> last.Homology;
 ## [ [ 1, [  ] ], [ 4, [  ] ], [ 2, [  ] ] ]
 ## gap> SCSeriesCSTSurface(2,10);  
 ## gap> last.Homology;                    
 ## [ [ 0, [  ] ], [ 1, [ 2 ] ], [ 0, [  ] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2147,7 +2147,7 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## <C>SCSeriesHandleBody(d,n)</C> generates a transitive <M>d</M>-dimensional handle body (<M>d \geq 3</M>) with <M>n</M> vertices (<M>n \geq 2d + 1</M>). The handle body is orientable if <M>d</M> is odd or if <M>d</M> and <M>n</M> are even, otherwise it is not orientable. The complex equals the difference cycle <M>(1 : \ldots : 1 : n-d)</M> To obtain the boundary complexes of <C>SCSeriesHandleBody(d,n)</C> use the function <Ref Func="SCSeriesBdHandleBody"/>. Internally calls <Ref Func="SCFromDifferenceCycles"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCSeriesHandleBody(3,7);
 ## gap> SCAutomorphismGroup(c);    
 ## PrimitiveGroup(7,2) = D(2*7)
@@ -2156,7 +2156,7 @@ end);
 ## PrimitiveGroup(7,4) = AGL(1, 7)
 ## gap> SCIsIsomorphic(bd,SCSeriesBdHandleBody(2,7));
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2192,12 +2192,12 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## <C>SCSeriesBdHandleBody(d,n)</C> generates a transitive <M>d</M>-dimensional sphere bundle (<M>d \geq 2</M>) with <M>n</M> vertices (<M>n \geq 2d + 3</M>) which coincides with the boundary of <Ref Func="SCSeriesHandleBody"/><C>(d,n)</C>. The sphere bundle is orientable if <M>d</M> is even or if <M>d</M> is odd and <M>n</M> is even, otherwise it is not orientable. Internally calls <Ref Func="SCFromDifferenceCycles"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCSeriesBdHandleBody(2,7);
 ## gap> SCLib.DetermineTopologicalType(c);
 ## gap> SCIsIsomorphic(c,SCSeriesHandleBody(3,7).Boundary);
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2234,7 +2234,7 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Generates the <Arg>k</Arg>-th member (<M>k \geq 7</M>) of the series <C>Le</C> from <Cite Key="Spreer10Diss"/>, Section 4.5.1. The series can be constructed as the generalization of the boundary of a genus <M>1</M> handlebody decomposition of the manifold <C>manifold_3_14_1_5</C> from the classification in <Cite Key="Lutz03TrigMnfFewVertVertTrans"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCSeriesLe(7);                     
 ## gap> d:=SCLib.DetermineTopologicalType(c);;
 ## gap> SCReference(d);
@@ -2243,7 +2243,7 @@ end);
 ## and vertex-transitive group actions', Doctoral Thesis TU Berlin 1999, Shaker-V\
 ## erlag, Aachen 1999"
 ## gap>  
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2274,7 +2274,7 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Generates the <Arg>k</Arg>-th member (<M>k \geq 0</M>) of the series <Arg>L^i</Arg>, <M>1 \leq i \leq 18</M>  from <Cite Key="Spreer10Diss"/>. The <M>18</M> series describe a complete classification of all series of cyclic <M>3</M>-manifolds with a fixed number of difference cycles of order <M>2</M> (i. e. there is a member of the series for every second integer, <M>f_0 (L^i (k+1) ) = f_0 (L^i (k)) +2</M>) and at least one member with less than <M>15</M> vertices where each series does not appear as a sub series of one of the series <M>K^i</M> from <Ref Func="SCSeriesK"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> cc:=List([1..18],x->SCSeriesL(x,0));;
 ## gap> Set(List(cc,x->x.F));
 ## [ [ 10, 45, 70, 35 ], [ 12, 60, 96, 48 ], [ 12, 66, 108, 54 ], 
@@ -2283,7 +2283,7 @@ end);
 ## gap> Set(List(cc,x->x.IsManifold));
 ## [ true ]
 ## gap>
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2337,14 +2337,14 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Generates the <Arg>k</Arg>-th member (<M>k \geq 0</M>) of the series <Arg>K^i</Arg>  (<M>1 \leq i \leq 396</M>) from <Cite Key="Spreer10Diss"/>.  The <M>396</M> series describe a complete classification of all dense series (i. e. there is a member of the series for every integer, <M>f_0 (K^i (k+1) ) = f_0 (K^i (k)) +1</M>) of cyclic <M>3</M>-manifolds with a fixed number of difference cycles and at least one member with less than <M>23</M> vertices. See <Ref Func="SCSeriesL"/> for a list of series of order <M>2</M>.
-## <Example>
+## <Example><![CDATA[
 ## gap> cc:=List([1..10],x->SCSeriesK(x,0));;                                                                                                                                                                                                  
 ## gap> Set(List(cc,x->x.F));                                                                                                                                                                                                                        
 ## gap> cc:=List([1..10],x->SCSeriesK(x,10));;
 ## gap> gap> cc:=List([1..10],x->SCSeriesK(x,10));;
 ## gap> Set(List(cc,x->x.Homology));
 ## gap> Set(List(cc,x->x.IsManifold));
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2779,11 +2779,11 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Generates the well known triangulated torus <M>\{ (l:j:p-l-j),(l:p-l-j:j) \}</M> with <M>p</M> vertices, <M>3p</M> edges and <M>2p</M> triangles where <M>j</M> has to be greater than <M>l</M> and <M>p</M> must be any prime number greater than <M>6</M>.
-## <Example>
+## <Example><![CDATA[
 ## gap> l:=List([2..19],x->SCSeriesPrimeTorus(1,x,41));; 
 ## gap> Set(List(l,x->SCHomology(x)));
 ## gap> 
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2816,7 +2816,7 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Generates the first neighborly sphere bundle NSB<M>_1</M> from <Cite Key="Spreer10Diss"/>, Section 4.5.4. The complex has <M>2k+1</M> vertices, <M>k \geq 4</M>
-## <Example>
+## <Example><![CDATA[
 ## gap> List([4..10],x->SCNeighborliness(SCSeriesNSB1(x)));
 ## [ 2, 2, 2, 2, 2, 2, 2 ]
 ## gap> List([4..10],x->SCFVector(SCSeriesNSB1(x)));        
@@ -2824,7 +2824,7 @@ end);
 ##   [ 15, 105, 180, 90 ], [ 17, 136, 238, 119 ], [ 19, 171, 304, 152 ], 
 ##   [ 21, 210, 378, 189 ] ]
 ## gap>  
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2857,14 +2857,14 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Generates the second neighborly sphere bundle NSB<M>_2</M> from <Cite Key="Spreer10Diss"/>, Section 4.5.4. The complex has <M>2k</M> vertices, <M>k \geq 5</M>
-## <Example>
+## <Example><![CDATA[
 ## gap> List([5..10],x->SCNeighborliness(SCSeriesNSB2(x)));
 ## [ 2, 2, 2, 2, 2, 2 ]
 ## gap> List([5..10],x->SCFVector(SCSeriesNSB2(x)));       
 ## [ [ 10, 45, 70, 35 ], [ 12, 66, 108, 54 ], [ 14, 91, 154, 77 ], 
 ##   [ 16, 120, 208, 104 ], [ 18, 153, 270, 135 ], [ 20, 190, 340, 170 ] ]
 ## gap> 
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2897,14 +2897,14 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Generates the third neighborly sphere bundle NSB<M>_3</M> from <Cite Key="Spreer10Diss"/>, Section 4.5.4. The complex has <M>k</M> vertices, <M>k \geq 11</M>
-## <Example>
+## <Example><![CDATA[
 ## gap> List([11..15],x->SCNeighborliness(SCSeriesNSB3(x)));
 ## [ 2, 2, 2, 2, 2 ]
 ## gap> List([11..15],x->SCFVector(SCSeriesNSB3(x)));       
 ## [ [ 11, 55, 88, 44 ], [ 12, 66, 108, 54 ], [ 13, 78, 130, 65 ], 
 ##   [ 14, 91, 154, 77 ], [ 15, 105, 180, 90 ] ]
 ## gap> 
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2938,10 +2938,10 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>	
 ## Generates the <M>d</M>-torus described in <Cite Key="Kuehnel86HigherDimCsaszar"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> t4:=SCSeriesTorus(4);
 ## gap> t4.Homology;
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2984,18 +2984,18 @@ end);
 ## <Description>	
 ## Generates the lens space <M>L(p,q)</M> whenever <M>p = (k+2)^2-1</M> and <M>q = k+2</M> or <M>p = 2k+3</M> and <M>q = 1</M>
 ## for a <M>k \geq 0</M> and <K>fail</K> otherwise. All complexes have a transitive cyclic automorphism group.
-## <Example>
+## <Example><![CDATA[
 ## gap> l154:=SCSeriesLensSpace(15,4);
 ## gap> l154.Homology;
 ## gap> g:=SimplifiedFpGroup(SCFundamentalGroup(l154));
 ## gap> StructureDescription(g);
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> l151:=SCSeriesLensSpace(15,1);
 ## gap> l151.Homology;
 ## gap> g:=SimplifiedFpGroup(SCFundamentalGroup(l151));
 ## gap> StructureDescription(g);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -3042,14 +3042,14 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>	
 ## Generates a neighborly 3-torus with <Arg>n</Arg> vertices if <Arg>n</Arg> is odd and a centrally symmetric 3-torus if <Arg>n</Arg> is even (<Arg>n</Arg><M>\geq 15</M> . The triangulations are taken from <Cite Key="Brehm09LatticeTrigE33Torus"/>
-## <Example>
+## <Example><![CDATA[
 ## gap> T3:=SCSeriesBrehmKuehnelTorus(15);
 ## gap> T3.Homology;
 ## gap> T3.Neighborliness;
 ## gap> T3:=SCSeriesBrehmKuehnelTorus(16);
 ## gap> T3.Homology;
 ## gap> T3.IsCentrallySymmetric;
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -3180,12 +3180,12 @@ end;
 ## Generates a combinatorial Brieskorn homology sphere of type <M>\Sigma (p,q,r)</M>, <M>p</M>, <M>q</M> and <M>r</M>
 ## pairwise co-prime. The complex is a combinatorial <M>3</M>-manifold with transitive cyclic symmetry
 ## as described in <Cite Key="Spreer12VarCyclPolytope"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCSeriesHomologySphere(2,3,5);
 ## gap> c.Homology;
 ## gap> c:=SCSeriesHomologySphere(3,4,13);
 ## gap> c.Homology;
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -3220,12 +3220,12 @@ end);
 ## Generates a combinatorial manifold of type <M>(S^2 x S^1)^{\#k}</M> for <M>k</M> even. 
 ## The complex is a combinatorial <M>3</M>-manifold with transitive cyclic symmetry
 ## as described in <Cite Key="Spreer12VarCyclPolytope"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCSeriesConnectedSum(12);
 ## gap> c.Homology;
 ## gap> g:=SimplifiedFpGroup(SCFundamentalGroup(c));
 ## gap> RelatorsOfFpGroup(g);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -3267,10 +3267,10 @@ end);
 ##
 ## The complexes are combinatorial <M>3</M>-manifolds with transitive cyclic symmetry
 ## as described in <Cite Key="Spreer12VarCyclPolytope"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCSeriesSeifertFibredSpace(2,3,15);
 ## gap> c.Homology;
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -3342,20 +3342,20 @@ end);
 ## If <Arg>orient</Arg> is <C>true</C> and <Arg>g</Arg><M> \geq 50</M> or if 
 ## <Arg>orient</Arg> is <C>false</C> and <Arg>g</Arg><M> \geq 100</M> only the difference cycles of the
 ## surface are returned
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCSurface(23,true); 
 ## gap> c.Homology;
 ## gap> c.TopologicalType;
 ## gap> c:=SCSurface(23,false); 
 ## gap> c.Homology;
 ## gap> c.TopologicalType;
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> dc:=SCSurface(345,true);
 ## gap> c:=SCFromDifferenceCycles(dc);
 ## gap> c.Chi;
 ## gap> dc:=SCSurface(12345678910,true); time;
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -3509,10 +3509,10 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>	
 ## Generates a combinatorial version of <M>(S^2 \times S^2)^{\# k}</M>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCSeriesS2xS2(3);
 ## gap> c.Homology;
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>

--- a/lib/glprops.gi
+++ b/lib/glprops.gi
@@ -15,11 +15,11 @@
 ## <Returns>simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes a spanning tree of a connected simplicial complex <Arg>complex</Arg> using a greedy algorithm.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SC([["a","b","c"],["a","b","d"], ["a","c","d"], ["b","c","d"]]);;
 ## gap> s:=SCSpanningTree(c);
 ## gap> s.Facets;
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -93,13 +93,13 @@ end);
 ## <Returns>a &GAP; fp group upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the first fundamental group of <Arg>complex</Arg>, which must be a connected simplicial complex, and returns it in form of a finitely presented group. The generators of the group are given as 2-tuples that correspond to the edges of <Arg>complex</Arg> in standard labeling. You can use GAP's <C>SimplifiedFpGroup</C> to simplify the group presenation.
-## <Example>
+## <Example><![CDATA[
 ## # an RP^2
 ## gap> list:=SCLib.SearchByName("RP^2");
 ## gap> c:=SCLib.Load(list[1][1]);
 ## gap> g:=SCFundamentalGroup(c);;
 ## gap> StructureDescription(g);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -291,10 +291,10 @@ end;
 ## <Returns> a list of face lists upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes all missing proper faces of a simplicial complex <Arg>complex</Arg> by calling <Ref Meth="SCMinimalNonFacesEx"/>. The simplices are returned in the original labeling of <Arg>complex</Arg>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCFromFacets(["abc","abd"]);;
 ## gap> SCMinimalNonFaces(c);           
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -341,13 +341,13 @@ end);
 ## <Returns> a list of face lists upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes all missing proper faces of a simplicial complex <Arg>complex</Arg>, i.e. the missing <M>(i+1)</M>-tuples in the <M>i</M>-dimensional skeleton of a <Arg>complex</Arg>. A missing <M>i+1</M>-tuple is not listed if it only consists of missing <M>i</M>-tuples. Note that whenever <Arg>complex</Arg> is <M>k</M>-neighborly the first <M>k+1</M> entries are empty. The simplices are returned in the standard labeling <M>1,\dots,n</M>, where <M>n</M> is the number of vertices of <Arg>complex</Arg>. 
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("T^2"){[1..10]}; 
 ## gap> torus:=SCLib.Load(last[1][1]);;
 ## gap> SCFVector(torus);
 ## gap> SCMinimalNonFacesEx(torus);
 ## gap> SCMinimalNonFacesEx(SCBdCrossPolytope(4));
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -365,14 +365,14 @@ end);
 ## <Returns><K>true</K> or <K>false</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Checks if a simplicial complex <Arg>complex</Arg> is the empty complex, i. e. a <C>SCSimplicialComplex</C> object with empty facet list.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SC([[1]]);;
 ## gap> SCIsEmpty(c);
 ## gap> c:=SC([]);;
 ## gap> SCIsEmpty(c);
 ## gap> c:=SC([[]]);;
 ## gap> SCIsEmpty(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -404,10 +404,10 @@ end);
 ## <Returns> a facet list upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Returns the facets of a simplicial complex as they are stored, i. e. with standard vertex labeling from 1 to n.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SC([[2,3],[3,4],[4,2]]);;
 ## gap> SCFacetsEx(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -431,10 +431,10 @@ end);
 ## <Returns> a facet list upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Returns the facets of a simplicial complex in the original vertex labeling.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SC([[2,3],[3,4],[4,2]]);;
 ## gap> SCFacets(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -498,12 +498,12 @@ end);
 ## <Returns> an integer <M>\geq -1</M> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the dimension of a simplicial complex. If the complex is not pure, the dimension of the highest dimensional simplex is returned.
-## <Example>
+## <Example><![CDATA[
 ## gap> complex:=SC([[1,2,3], [1,2,4], [1,3,4], [2,3,4]]);;
 ## gap> SCDim(complex);                                    
 ## gap> c:=SC([[1], [2,4], [3,4], [5,6,7,8]]);;
 ## gap> SCDim(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -543,10 +543,10 @@ end);
 ## <Returns> a list of the type <M>\{ \pm 1 \}^{f_d}</M> or <C>[ ]</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## This function tries to compute an orientation of a pure simplicial complex <Arg>complex</Arg> that fulfills the weak pseudomanifold property. If <Arg>complex</Arg> is orientable, an orientation in form of a list of orientations for the facets of <Arg>complex</Arg> is returned, otherwise an empty set.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdCrossPolytope(4);;
 ## gap> SCOrientation(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -695,12 +695,12 @@ end);
 ## <Returns> a boolean upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Checks if a simplicial complex <Arg>complex</Arg> is pure.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SC([[1,2], [1,4], [2,4], [2,3,4]]);;
 ## gap> SCIsPure(c);
 ## gap> c:=SC([[1,2], [1,4], [2,4]]);;
 ## gap> SCIsPure(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -745,13 +745,13 @@ end);
 ## <Meth Name="SCIsKNeighborly" Arg="complex,k"/>
 ## <Returns><K>true</K> or <K>false</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("RP^2");   
 ## gap> rp2_6:=SCLib.Load(last[1][1]);;
 ## gap> SCFVector(rp2_6);
 ## gap> SCIsKNeighborly(rp2_6,2);
 ## gap> SCIsKNeighborly(rp2_6,3);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -786,11 +786,11 @@ end);
 ## <Returns><K>true</K> or <K>false</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Checks if <Arg>complex</Arg> is flag. A connected simplicial complex of dimension at least one is a flag complex if all cliques in its 1-skeleton span a face of the complex (cf. <Cite Key="Frohmader08FaceVecFlagCompl" />). 
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("RP^2");   
 ## gap> rp2_6:=SCLib.Load(last[1][1]);;
 ## gap> SCIsFlag(rp2_6);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -850,10 +850,10 @@ end);
 ## <Returns> a list of non-negative integers upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the <M>f</M>-vector of the simplicial complex <Arg>complex</Arg>, i. e. the number of <M>i</M>-dimensional faces for <M> 0 \leq i \leq d </M>, where <M>d</M> is the dimension of <Arg>complex</Arg>. A memory-saving implicit algorithm is used that avoids calculating the face lattice of the complex. Internally calls <Ref Meth="SCNumFaces"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> complex:=SC([[1,2,3], [1,2,4], [1,3,4], [2,3,4]]);;
 ## gap> SCFVector(complex);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -895,11 +895,11 @@ end);
 ## <Returns> an integer or a list of integers upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## If <Arg>i</Arg> is not specified the function computes the <M>f</M>-vector of the simplicial complex <Arg>complex</Arg> (cf. <Ref Meth="SCFVector"/>). If the optional integer parameter <Arg>i</Arg> is passed, only the <Arg>i</Arg>-th position of the <M>f</M>-vector of <Arg>complex</Arg> is calculated. In any case a memory-saving implicit algorithm is used that avoids calculating the face lattice of the complex. 
-## <Example>
+## <Example><![CDATA[
 ## gap> complex:=SC([[1,2,3], [1,2,4], [1,3,4], [2,3,4]]);;
 ## gap> SCNumFaces(complex,1);
 ## 4
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1003,12 +1003,12 @@ end);
 ## <Description>
 ## Computes the <M>h</M>-vector of a simplicial complex. The <M>h</M>-vector is defined as <Math> h_{k}:= \sum \limits_{i=-1}^{k-1} (-1)^{k-i-1}{d-i-1 \choose k-i-1} f_i</Math> for <M>0 \leq k \leq d</M>, where <M>f_{-1} := 1</M>. For all simplicial complexes we have <M>h_0 = 1</M>, hence the returned list starts with the second entry of the <M>h</M>-vector.
 ##
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("RP^2");
 ## gap> rp2_6:=SCLib.Load(last[1][1]);;
 ## gap> SCFVector(rp2_6);
 ## gap> SCHVector(rp2_6);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1052,13 +1052,13 @@ end);
 ## 
 ## Let <M>h</M> be the <M>h</M>-vector of a <M>d</M>-dimensional simplicial complex C, then <Math>g_i:=h_{i+1} - h_{i} ; \quad \frac{d}{2} 
 ## \geq i \geq 0 </Math> is called the <M>g</M>-vector of <M>C</M>. For the definition of the <M>h</M>-vector see <Ref Meth="SCHVector" />. The information contained in <M>g</M> suffices to determine the <M>f</M>-vector of <M>C</M>.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("RP^2");
 ## gap> rp2_6:=SCLib.Load(last[1][1]);;
 ## gap> SCFVector(rp2_6);
 ## gap> SCHVector(rp2_6);
 ## gap> SCGVector(rp2_6);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1101,12 +1101,12 @@ end);
 ## <Returns> integer upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the Euler characteristic <Math> \chi(C)=\sum \limits_{i=0}^{d} (-1)^{i} f_i </Math> of a simplicial complex <M>C</M>, where <M>f_i</M> denotes the <M>i</M>-th component of the <M>f</M>-vector.
-## <Example>
+## <Example><![CDATA[
 ## gap> complex:=SCFromFacets([[1,2,3], [1,2,4], [1,3,4], [2,3,4]]);;
 ## gap> SCEulerCharacteristic(complex);
 ## gap> s2:=SCBdSimplex(3);;
 ## gap> s2.EulerCharacteristic;
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1140,14 +1140,14 @@ end);
 ## <Returns><K>true</K> or <K>false</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Checks if a simplicial complex <Arg>complex</Arg> fulfills the weak pseudomanifold property, i. e. if every <M>d-1</M>-face of <Arg>complex</Arg> is contained in at most <M>2</M> facets.
-## <Example>
+## <Example><![CDATA[
 ## # Two 2-spheres glued together at [1]
 ## gap> c:=SC([[1,2,3],[1,2,4],[1,3,4],[2,3,4],[1,5,6],[1,5,7],[1,6,7],[5,6,7]]);;
 ## gap> SCIsPseudoManifold(c);
 ## # Two circles glued together a 1
 ## gap> c:=SC([[1,2],[2,3],[3,1],[1,4],[4,5],[5,1]]);;
 ## gap> SCIsPseudoManifold(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1245,12 +1245,12 @@ end);
 ## <Returns><K>true</K> or <K>false</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Checks if a simplicial complex <Arg>complex</Arg> is connected.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(1);;
 ## gap> SCIsConnected(c);
 ## gap> c:=SCBdSimplex(2);;
 ## gap> SCIsConnected(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1302,12 +1302,12 @@ end);
 ## <Returns><K>true</K> or <K>false</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Checks if a simplicial complex <Arg>complex</Arg> is strongly connected, i. e. if for any pair of facets <M>(\hat{\Delta},\tilde{\Delta})</M> there exists a sequence of facets <M>( \Delta_1 , \ldots , \Delta_k )</M> with <M>\Delta_1 = \hat{\Delta}</M> and <M>\Delta_k = \tilde{\Delta}</M> and dim<M>(\Delta_i , \Delta_{i+1} ) = d - 1</M> for all <M>1 \leq i \leq k - 1</M>.  
-## <Example>
+## <Example><![CDATA[
 ## # Two 2-spheres, glued along [1]
 ## gap> c:=SC([[1,2,3],[1,2,4],[1,3,4],[2,3,4], [1,5,6],[1,5,7],[1,6,7],[5,6,7]]);
 ## gap> SCIsConnected(c);        
 ## gap> SCIsStronglyConnected(c);                                                
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1416,7 +1416,7 @@ end);
 ## Computes the Altshuler-Steinberg determinant.<P/>
 ## Definition: Let <M>v_i</M>, <M>1 \leq i \leq n</M> be the vertices and let  <M>F_j</M>, <M>1 \leq j \leq m</M> be the facets of a pure simplicial complex <M>C</M>, then the determinant of <M>AS \in \mathbb{Z}^{n \times m}</M>, <M>AS_{ij}=1</M> if <M>v_i \in F_j</M>, <M>AS_{ij}=0</M> otherwise, is called the Altshuler-Steinberg matrix. The Altshuler-Steinberg determinant is the determinant of the quadratic matrix <M>AS \cdot AS^T</M>.<P/>
 ## The Altshuler-Steinberg determinant is a combinatorial invariant of <M>C</M> and can be checked before searching for an isomorphism between two simplicial complexes. 
-## <Example>
+## <Example><![CDATA[
 ## gap> list:=SCLib.SearchByName("T^2");; 
 ## gap> torus:=SCLib.Load(last[1][1]);;
 ## gap> SCAltshulerSteinberg(torus);
@@ -1426,7 +1426,7 @@ end);
 ## gap> SCAltshulerSteinberg(c);
 ## gap> c:=SCBdSimplex(5);;
 ## gap> SCAltshulerSteinberg(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1489,7 +1489,7 @@ end);
 ## is returned in form of a list <M>[ f, [t_1,...,t_n] ]</M>, where <M>f</M> is the (integer) 
 ## free part of <M>H_i</M> and <M>t_i</M> denotes the torsion parts of <M>H_i</M> ordered in 
 ## weakly increasing size.<P/>
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("K^2");
 ## gap> kleinBottle:=SCLib.Load(last[1][1]);;
 ## gap> kleinBottle.Homology;          
@@ -1499,7 +1499,7 @@ end);
 ## gap> SCHomology(c);
 ## gap> SCFpBettiNumbers(c,2);
 ## gap> SCFpBettiNumbers(c,3);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1514,13 +1514,13 @@ end);
 ## <Returns> a list of non-negative integers upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the Betti numbers of a simplicial complex with respect to the field <M>\mathbb{F}_p</M> for any prime number <C>p</C>.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("K^2");    
 ## gap> kleinBottle:=SCLib.Load(last[1][1]);; 
 ## gap> SCHomology(kleinBottle);      
 ## gap> SCFpBettiNumbers(kleinBottle,2);
 ## gap> SCFpBettiNumbers(kleinBottle,3);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1582,7 +1582,7 @@ end);
 ## <Returns>1-dimensional simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the dual graph of the pure simplicial complex <Arg>complex</Arg>.
-## <Example>
+## <Example><![CDATA[
 ## gap> sphere:=SCBdSimplex(5);;
 ## gap> graph:=SCFaces(sphere,1);       
 ## [ [ 1, 2 ], [ 1, 3 ], [ 1, 4 ], [ 1, 5 ], [ 1, 6 ], [ 2, 3 ], [ 2, 4 ], 
@@ -1592,7 +1592,7 @@ end);
 ## gap> dualGraph:=SCDualGraph(sphere); 
 ## gap> graph.Facets = dualGraph.Facets;
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1677,11 +1677,11 @@ end);
 ## The function uses an efficient algorithm provided by the package <Package>GRAPE</Package> (see <Cite Key="Soicher06GRAPE"/>, which is based on the program <C>nauty</C> by Brendan McKay <Cite Key="McKay84Nauty"/>).
 ## If the package <Package>GRAPE</Package> is not available, this function call falls back to <Ref Meth="SCAutomorphismGroupInternal"/>.<P/>
 ## The position of the group in the &GAP; libraries of small groups, transitive groups or primitive groups is given. If the group is not listed, its structure description, provided by the &GAP; function <C>StructureDescription()</C>, is returned as the name of the group. Note that the latter form is not always unique, since every non trivial semi-direct product is denoted by ''<C>:</C>''.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("K3");            
 ## gap> k3surf:=SCLib.Load(last[1][1]);; 
 ## gap> SCAutomorphismGroup(k3surf);               
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1699,11 +1699,11 @@ end);
 ## <Returns>a positive integer group upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the size of the automorphism group of a strongly connected pseudomanifold <Arg>complex</Arg>, see <Ref Meth="SCAutomorphismGroup"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("K3");            
 ## gap> k3surf:=SCLib.Load(last[1][1]);;           
 ## gap> SCAutomorphismGroupSize(k3surf);               
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1728,11 +1728,11 @@ end);
 ## <Returns>the &GAP; structure description upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the &GAP; structure description of the automorphism group of a strongly connected pseudomanifold <Arg>complex</Arg>, see <Ref Meth="SCAutomorphismGroup"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("K3");     
 ## gap> k3surf:=SCLib.Load(last[1][1]);;      
 ## gap> SCAutomorphismGroupStructure(k3surf);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1757,11 +1757,11 @@ end);
 ## <Returns>a positive integer upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the transitivity of the automorphism group of a strongly connected pseudomanifold <Arg>complex</Arg>, i. e. the maximal integer <M>t</M> such that for any two ordered <M>t</M>-tuples <M>T_1</M> and <M>T_2</M> of vertices of <Arg>complex</Arg>, there exists an element <M>g</M> in the automorphism group of <Arg>complex</Arg> for which <M>gT_1=T_2</M>, see <Cite Key="Huppert67EndlGruppen" />. 
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("K3");            
 ## gap> k3surf:=SCLib.Load(last[1][1]);;           
 ## gap> SCAutomorphismGroupTransitivity(k3surf);               
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2066,12 +2066,12 @@ end;
 ## <Description>
 ## Computes the automorphism group of a strongly connected pseudomanifold <Arg>complex</Arg>, i. e. the group of all automorphisms on the set of vertices of <Arg>complex</Arg> that do not change the complex as a whole. Necessarily the group is a subgroup of the symmetric group <M>S_n</M> where <M>n</M> is the number of vertices of the simplicial complex.<P/>
 ## The position of the group in the &GAP; libraries of small groups, transitive groups or primitive groups is given. If the group is not listed, its structure description, provided by the &GAP; function <C>StructureDescription()</C>, is returned as the name of the group. Note that the latter form is not always unique, since every non trivial semi-direct product is denoted by ''<C>:</C>''.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(5);;
 ## gap> SCAutomorphismGroupInternal(c);
 ## S6
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> c:=SC([[1,2],[2,3],[1,3]]);;
 ## gap> g:=SCAutomorphismGroupInternal(c);
 ## PrimitiveGroup(3,2) = S(3)
@@ -2079,7 +2079,7 @@ end;
 ## [ (), (1,2,3), (1,3,2), (2,3), (1,2), (1,3) ]
 ## gap> StructureDescription(g);
 ## "S3"
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2198,19 +2198,19 @@ end);
 ## Computes the generators of a simplicial complex in the standard vertex labeling.<P/>
 ## The generating set of a simplicial complex is a list of simplices that will generate the complex by uniting their <M>G</M>-orbits if <M>G</M> is the automorphism group of <Arg>complex</Arg>.<P/>
 ## The function returns the simplices together with the length of their orbits.
-## <Example>
+## <Example><![CDATA[
 ## gap> list:=SCLib.SearchByName("T^2");;
 ## gap> torus:=SCLib.Load(list[1][1]);;
 ## gap> SCGeneratorsEx(torus); 
 ## [ [ [ 1, 2, 4 ], 14 ] ]
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("K3");
 ## [ [ 520, "K3_16" ], [ 539, "K3_17" ] ]
 ## gap> SCLib.Load(last[1][1]);
 ## gap> SCGeneratorsEx(last);
 ## [ [ [ 1, 2, 3, 8, 12 ], 240 ], [ [ 1, 2, 5, 8, 14 ], 48 ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2250,19 +2250,19 @@ end);
 ## Computes the generators of a simplicial complex in the original vertex labeling.<P/>
 ## The generating set of a simplicial complex is a list of simplices that  will generate the complex by uniting their <M>G</M>-orbits if <M>G</M> is the automorphism group of <Arg>complex</Arg>.<P/>
 ## The function returns the simplices together with the length of their orbits.
-## <Example>
+## <Example><![CDATA[
 ## gap> list:=SCLib.SearchByName("T^2");;
 ## gap> torus:=SCLib.Load(list[1][1]);;
 ## gap> SCGenerators(torus); 
 ## [ [ [ 1, 2, 4 ], 14 ] ]
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("K3");
 ## [ [ 520, "K3_16" ], [ 539, "K3_17" ] ]
 ## gap> SCLib.Load(last[1][1]);
 ## gap> SCGenerators(last);
 ## [ [ [ 1, 2, 3, 8, 12 ], 240 ], [ [ 1, 2, 5, 8, 14 ], 48 ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2301,11 +2301,11 @@ end);
 ##
 ## The function returns the difference cycles as lists where the sum of the entries
 ## equals the number of vertices <M>n</M> of <Arg>complex</Arg>.
-## <Example>
+## <Example><![CDATA[
 ## gap> torus:=SCFromDifferenceCycles([[1,2,4],[1,4,2]]);
 ## gap> torus.Homology;
 ## gap> torus.DifferenceCycles;
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2361,16 +2361,16 @@ end);
 ## <Returns><K>true</K> or <K>false</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Checks if a simplicial complex <Arg>complex</Arg> is centrally symmetric, i. e. if its automorphism group contains a fixed point free involution.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdCrossPolytope(4);;
 ## gap> SCIsCentrallySymmetric(c);
 ## true
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(4);;
 ## gap> SCIsCentrallySymmetric(c);
 ## false
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2419,10 +2419,10 @@ end);
 ## <Returns>an automorphism of <Arg>complex</Arg> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Returns the centrally symmetric element of the automorphism group of  <Arg>complex</Arg> if the simplicial complex <Arg>complex</Arg> is centrally symmetric.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdCrossPolytope(4);;
 ## gap> SCCentrallySymmetricElement(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2473,7 +2473,7 @@ end);
 ## <Description>
 ## Returns <M>k</M> if a simplicial complex <Arg>complex</Arg> is <M>k</M>-neighborly but not  <M>(k+1)</M>-neighborly. See also <Ref Meth="SCIsKNeighborly" />.<P/>
 ## Note that every complex is at least <M>1</M>-neighborly.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(4);;
 ## gap> SCNeighborliness(c);
 ## 4
@@ -2485,7 +2485,7 @@ end);
 ## gap> cp2:=SCLib.Load(last[1][1]);;
 ## gap> SCNeighborliness(cp2);
 ## 3
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2528,12 +2528,12 @@ end);
 ## The simplicial complex <Arg>complex</Arg> must be pure, strongly connected and must fulfill the weak pseudomanifold property with non-empty boundary (cf. <Ref Meth="SCBoundary"/>).<P/>
 ## The function checks whether <Arg>complex</Arg> is shellable or not. An ordering <M>(F_1, F_2, \ldots , F_r)</M> on the facet list of a simplicial complex is called a shelling if and only if <M>F_i \cap (F_1 \cup \ldots \cup F_{i-1})</M> is a pure simplicial complex of dimension <M>d-1</M> for all <M>i = 1, \ldots , r</M>. A simplicial complex is called shellable, if at least one shelling exists.<P/>
 ## See <Cite Key="Ziegler95LectPolytopes" />, <Cite Key="Pachner87KonstrMethKombHomeo" /> to learn more about shellings.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdCrossPolytope(4);;       
 ## gap> c:=Difference(c,SC([[1,3,5,7]]));; # bounded version
 ## gap> SCIsShellable(c);
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2570,11 +2570,11 @@ end);
 ## <Returns><K>true</K> or <K>false</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Checks if a simplicial complex <Arg>complex</Arg>, satisfying the weak pseudomanifold property, is orientable.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdCrossPolytope(4);;
 ## gap> SCIsOrientable(c);
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2624,11 +2624,11 @@ end);
 ## The function computes the boundary of a simplicial complex <Arg>complex</Arg> satisfying the weak pseudomanifold property and returns it as a simplicial complex. In addition, it is stored as a property of <Arg>complex</Arg>.<P/>
 ## The boundary of a simplicial complex is defined as the simplicial complex consisting of all <M>d-1</M>-faces that are contained in exactly one facet. <P/>
 ## If <Arg>complex</Arg> does not fulfill the weak pseudomanifold property (i. e. if the valence of any <M>d-1</M>-face exceeds <M>2</M>) the function returns <K>fail</K>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SC([[1,2,3,4],[1,2,3,5],[1,2,4,5],[1,3,4,5]]);
 ## gap> SCBoundary(c);
 ## gap> c;  
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2697,18 +2697,18 @@ end);
 ## <Returns><K>true</K> or <K>false</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Checks if a simplicial complex <Arg>complex</Arg> that fulfills the weak pseudo manifold property has a boundary, i. e. <M>d-1</M>-faces of valence <M>1</M>. If <Arg>complex</Arg> is closed <K>false</K> is returned, if <Arg>complex</Arg> does not fulfill the weak pseudomanifold property, <K>fail</K> is returned, otherwise <K>true</K> is returned.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("K^2"); 
 ## [ [ 18, "K^2 (VT)" ], [ 221, "K^2 (VT)" ] ]
 ## gap> kleinBottle:=SCLib.Load(last[1][1]);;
 ## gap> SCHasBoundary(kleinBottle);
 ## false
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> c:=SC([[1,2,3,4],[1,2,3,5],[1,2,4,5],[1,3,4,5]]);;
 ## gap> SCHasBoundary(c);
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2753,7 +2753,7 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes all <M>d-1</M>-faces of valence <M>2</M> of a simplicial complex <Arg>complex</Arg> that fulfills the weak pseudomanifold property, i. e. the function returns the part of the <M>d-1</M>-skeleton of <M>C</M> that is not part of the boundary. 
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SC([[1,2,3,4],[1,2,3,5],[1,2,4,5],[1,3,4,5]]);;
 ## gap> SCInterior(c).Facets;
 ## [[1, 2, 3], [1, 2, 4], [1, 2, 5], [1, 3, 4], [1, 3, 5],
@@ -2761,7 +2761,7 @@ end);
 ## gap> c:=SC([[1,2,3,4]]);;
 ## gap> SCInterior(c).Facets;
 ## []
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2837,14 +2837,14 @@ end);
 ## <Returns> <K>true</K> or <K>false</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Returns <K>true</K> if a simplicial complex <Arg>complex</Arg> that fulfills the weak pseudomanifold property has at least one <M>d-1</M>-face of valence <M>2</M>, i. e. if there exist at least one <M>d-1</M>-face that is not in the boundary of <Arg>complex</Arg>, if no such face can be found <K>false</K> is returned. It <Arg>complex</Arg> does not fulfill the weak pseudomanifold property <K>fail</K> is returned.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SC([[1,2,3,4],[1,2,3,5],[1,2,4,5],[1,3,4,5]]);;
 ## gap> SCHasInterior(c)
 ## true
 ## gap> c:=SC([[1,2,3,4]]);;
 ## gap> SCHasInterior(c);
 ## false
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2893,7 +2893,7 @@ end);
 ## <Returns><K>true</K> or <K>false</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Checks whether a given simplicial complex <Arg>complex</Arg> is a Eulerian manifold or not, i. e. checks if all vertex links of <Arg>complex</Arg> have the Euler characteristic of a sphere. In particular the function returns <K>false</K> in case <Arg>complex</Arg> has a non-empty boundary.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(4);;
 ## gap> SCIsEulerianManifold(c);
 ## true
@@ -2901,7 +2901,7 @@ end);
 ## gap> moebius:=SCLib.Load(last[1][1]); # a moebius strip
 ## gap> SCIsEulerianManifold(moebius);
 ## false
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2965,7 +2965,7 @@ end);
 ## <Returns> a face list or a list of face lists upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## If <Arg>k</Arg> is an integer, the <Arg>k</Arg>-skeleton of a simplicial complex <Arg>complex</Arg>, i. e. all <Arg>k</Arg>-faces of <Arg>complex</Arg>, is computed. If <Arg>k</Arg> is a list, a list of all <Arg>k</Arg><C>[i]</C>-faces of <Arg>complex</Arg> for each entry <Arg>k</Arg><C>[i]</C> (which has to be an integer) is returned. The faces are returned in the standard labeling.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("RP^2"); 
 ## [ [ 3, "RP^2 (VT)" ], [ 262, "RP^2xS^1" ] ]
 ## gap> rp2_6:=SCLib.Load(last[1][1]);;      
@@ -2978,7 +2978,7 @@ end);
 ## [ [ 11, 12 ], [ 11, 13 ], [ 11, 14 ], [ 11, 15 ], [ 11, 16 ], [ 12, 13 ], 
 ##   [ 12, 14 ], [ 12, 15 ], [ 12, 16 ], [ 13, 14 ], [ 13, 15 ], [ 13, 16 ], 
 ##   [ 14, 15 ], [ 14, 16 ], [ 15, 16 ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -3057,7 +3057,7 @@ end);
 ## <Returns> a face list or a list of face lists upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## If <Arg>k</Arg> is an integer, the <Arg>k</Arg>-skeleton of a simplicial complex <Arg>complex</Arg>, i. e. all <Arg>k</Arg>-faces of <Arg>complex</Arg>, is computed. If <Arg>k</Arg> is a list, a list of all <Arg>k</Arg><C>[i]</C>-faces of <Arg>complex</Arg> for each entry <Arg>k</Arg><C>[i]</C> (which has to be an integer) is returned. The faces are returned in the original labeling.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("RP^2"); 
 ## [ [ 3, "RP^2 (VT)" ], [ 262, "RP^2xS^1" ] ]
 ## gap> rp2_6:=SCLib.Load(last[1][1]);;      
@@ -3070,7 +3070,7 @@ end);
 ## [ [ 11, 12 ], [ 11, 13 ], [ 11, 14 ], [ 11, 15 ], [ 11, 16 ], [ 12, 13 ], 
 ##   [ 12, 14 ], [ 12, 15 ], [ 12, 16 ], [ 13, 14 ], [ 13, 15 ], [ 13, 16 ], 
 ##   [ 14, 15 ], [ 14, 16 ], [ 15, 16 ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -3100,13 +3100,13 @@ end);
 ## <Returns> a list of face lists upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the entire face lattice of a <M>d</M>-dimensional simplicial complex, i. e. all of its <M>i</M>-skeletons for <M>0 \leq i \leq d</M>. The faces are returned in the standard labeling.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SC([["a","b","c"],["a","b","d"], ["a","c","d"], ["b","c","d"]]);;
 ## gap> SCFaceLatticeEx(c);
 ## [ [ [1], [2], [3], [4] ],
 ##   [ [1, 2], [1, 3], [1, 4], [2, 3], [2, 4], [3, 4] ],
 ##   [ [1, 2, 3], [1, 2, 4], [1, 3, 4], [2, 3, 4] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -3141,7 +3141,7 @@ end);
 ## <Returns> a list of face lists upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the entire face lattice of a <M>d</M>-dimensional simplicial complex, i. e. all of its <M>i</M>-skeletons for <M>0 \leq i \leq d</M>. The faces are returned in the original labeling.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SC([["a","b","c"],["a","b","d"], ["a","c","d"], ["b","c","d"]]);;
 ## gap> SCFaceLattice(c);
 ## [ [ ["a"], ["b"], ["c"], ["d"] ],
@@ -3149,7 +3149,7 @@ end);
 ## 	   ["b", "c"], ["b", "d"], ["c", "d"] ],
 ##   [ ["a", "b", "c"], ["a", "b", "d"], 
 ##     ["a", "c", "d"], ["b", "c", "d"] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -3179,14 +3179,14 @@ end);
 ## <Returns> a list of face lists upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Returns a list of all <Arg>k</Arg>-faces of the simplicial complex <Arg>complex</Arg>. The list is sorted by the valence of the faces in the <Arg>k</Arg>+1-skeleton of the complex, i. e. the <M>i</M>-th entry of the list contains all <Arg>k</Arg>-faces of valence <M>i</M>. The faces are returned in the standard labeling.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SC([[1,2,3],[2,3,4],[3,4,5],[4,5,6],[1,5,6],[1,4,6],[2,3,6]]);;
 ## gap> SCIncidences(c,1);
 ## [ [ [1, 2], [1, 3], [1, 4], [1, 5], 
 ##     [2, 4], [2, 6], [3, 5], [3, 6] ], 
 ##   [ [1, 6], [3, 4], [4, 5], [4, 6], [5, 6] ],
 ##   [ [2, 3] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -3269,14 +3269,14 @@ end);
 ## <Returns> a list of face lists upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Returns a list of all <Arg>k</Arg>-faces of the simplicial complex <Arg>complex</Arg>. The list is sorted by the valence of the faces in the <Arg>k</Arg>+1-skeleton of the complex, i. e. the <M>i</M>-th entry of the list contains all <Arg>k</Arg>-faces of valence <M>i</M>. The faces are returned in the original labeling.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SC([[1,2,3],[2,3,4],[3,4,5],[4,5,6],[1,5,6],[1,4,6],[2,3,6]]);;
 ## gap> SCIncidences(c,1);
 ## [ [ [1, 2], [1, 3], [1, 4], [1, 5], 
 ##     [2, 4], [2, 6], [3, 5], [3, 6] ], 
 ##   [ [1, 6], [3, 4], [4, 5], [4, 6], [5, 6] ],
 ##   [ [2, 3] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -3314,11 +3314,11 @@ end);
 ## <Returns> <M>[ 1, \ldots , n ]</M> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Returns <M>\left[1, \ldots , n \right]</M>, where <M>n</M> is the number of vertices of a simplicial complex <Arg>complex</Arg>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SC([[1,4,5],[4,9,8],[12,13,14,15,16,17]]);;
 ## gap> SCVerticesEx(c);
 ## [1 .. 11]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -3341,14 +3341,14 @@ end);
 ## <Returns> a list of vertex labels of <Arg>complex</Arg> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Returns the vertex labels of a simplicial complex <Arg>complex</Arg>.
-## <Example>
+## <Example><![CDATA[
 ## gap> sphere:=SC([["x",45,[1,1]],["x",45,["b",3]],["x",[1,1],
 ##   ["b",3]],[45,[1,1],["b",3]]]);;
 ## gap> SCVerticesEx(sphere);
 ## [1, 2, 3, 4]
 ## gap> SCVertices(sphere);
 ## [ 45, [ 1, 1 ], "x", [ "b", 3 ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -3377,11 +3377,11 @@ end);
 ## <Returns> <K>true</K> or <K>false</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Checks whether a simplicial complex <Arg>complex</Arg> is a homology sphere, i. e. has the homology of a sphere, or not.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SC([[2,3],[3,4],[4,2]]);;
 ## gap> SCIsHomologySphere(c);
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -3423,7 +3423,7 @@ end);
 ## Checks whether the simplicial complex <Arg>complex</Arg> that must be a combinatorial <M>d</M>-manifold is in the class <M>\mathcal{K}^k(d)</M>, <M>1\leq k\leq \lfloor\frac{d+1}{2}\rfloor</M>, of simplicial complexes that only have <M>k</M>-stacked spheres as vertex links, see <Cite Key="Effenberger09StackPolyTightTrigMnf" />. Note that it is not checked whether <Arg>complex</Arg> is a combinatorial manifold -- if not, the algorithm will not succeed.
 ## Returns <K>true</K> / <K>false</K> upon success. If <K>true</K> is returned this means that <Arg>complex</Arg> is at least <Arg>k</Arg>-stacked and thus that the complex is in the class <M>\mathcal{K}^k(d)</M>, i.e. all vertex links are <C>i</C>-stacked spheres. If <K>false</K> is returnd the complex cannot be <Arg>k</Arg>-stacked. In some cases the question can not be decided. In this case <K>fail</K> is returned.<P/>
 ## Internally calls <Ref Meth="SCIsKStackedSphere"/> for all links. Please note that this is a radomized algorithm that may give an indefinite answer to the membership problem.
-## <Example>
+## <Example><![CDATA[
 ## gap> list:=SCLib.SearchByName("S^2~S^1"){[1..3]};;
 ## gap> c:=SCLib.Load(list[1][1]);;
 ## gap> c.AutomorphismGroup;
@@ -3439,7 +3439,7 @@ end);
 ## #I  SCIsInKd: complex has transitive automorphism group, all links are 
 ## 1-stacked.
 ## 1
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -3540,14 +3540,14 @@ end);
 ## <Returns> a <C>(d+1)</C><M>\times</M><C>Int(d+1/2)</C> matrix with integer entries upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the coefficients of the Dehn Sommerville equations for dimension <C>d</C>: <M>h_j - h_{d+1-j} = (-1)^{d+1-j} { d+1 \choose j } (\chi (M) - 2)</M> for <M>0 \leq j \leq \frac{d}{2}</M> and <M>d</M> even, and <M>h_j - h_{d+1-j} = 0</M> for <M>0 \leq j \leq \frac{d-1}{2}</M> and <M>d</M> odd. Where <M>h_j</M> is the <M>j</M>th component of the <M>h</M>-vector, see <Ref Func="SCHVector"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> m:=SCDehnSommervilleMatrix(6);;
 ## gap> PrintArray(m);
 ## [ [    1,   -1,    1,   -1,    1,   -1,    1 ],
 ##   [    0,   -2,    3,   -4,    5,   -6,    7 ],
 ##   [    0,    0,    0,   -4,   10,  -20,   35 ],
 ##   [    0,    0,    0,    0,    0,   -6,   21 ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -3610,14 +3610,14 @@ end);
 ## <Returns> <K>true</K> or <K>false</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Checks if the simplicial complex <Arg>c</Arg> fulfills the Dehn Sommerville equations: <M>h_j - h_{d+1-j} = (-1)^{d+1-j} { d+1 \choose j } (\chi (M) - 2)</M> for <M>0 \leq j \leq \frac{d}{2}</M> and <M>d</M> even, and <M>h_j - h_{d+1-j} = 0</M> for <M>0 \leq j \leq \frac{d-1}{2}</M> and <M>d</M> odd. Where <M>h_j</M> is the <M>j</M>th component of the <M>h</M>-vector, see <Ref Func="SCHVector"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdCrossPolytope(6);;
 ## gap> SCDehnSommervilleCheck(c);
 ## true
 ## gap> c:=SC([[1,2,3],[1,4,5]]);;
 ## gap> SCDehnSommervilleCheck(c);
 ## false
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -3791,11 +3791,11 @@ end;
 ## Computes a Heegaard splitting of the combinatorial <M>3</M>-manifold  <Arg>M</Arg>. The function returns the genus of the Heegaard splitting, the vertex partition of the Heegaard splitting and a note, that splitting is arbitrary and in particular possibly not minimal.
 ## 
 ## See also <Ref Func="SCHeegaardSplittingSmallGenus"/> for the calculation of a Heegaard splitting of small genus and <Ref Func="SCIsHeegaardSplitting"/> for a test whether or not a given splitting defines a Heegaard splitting.
-## <Example>
+## <Example><![CDATA[
 ## gap> M:=SCSeriesBdHandleBody(3,12);;
 ## gap> list:=SCHeegaardSplitting(M);
 ## gap> sl:=SCSlicing(M,list[2]);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -3816,12 +3816,12 @@ end);
 ## Computes a Heegaard splitting of the combinatorial <M>3</M>-manifold  <Arg>M</Arg> of small genus. The function returns the genus of the Heegaard splitting, the vertex partition of the Heegaard splitting and information whether the splitting is minimal or just small (i. e. the Heegaard genus could not be determined).
 ## 
 ## See also <Ref Func="SCHeegaardSplitting"/> for a faster computation of a Heegaard splitting of arbitrary genus and <Ref Func="SCIsHeegaardSplitting"/> for a test whether or not a given splitting defines a Heegaard splitting.
-## <Example> NOEXECUTE
+## <Example><![CDATA[ NOEXECUTE
 ## gap> c:=SCSeriesBdHandleBody(3,10);;
 ## gap> M:=SCConnectedProduct(c,3);;
 ## gap> list:=SCHeegaardSplittingSmallGenus(M);
 ## This creates an error
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -3917,13 +3917,13 @@ end);
 ## Checks whether <Arg>list</Arg> defines a Heegaard splitting of <Arg>c</Arg> or not.
 ## 
 ## See also <Ref Func="SCHeegaardSplitting"/> and <Ref Func="SCHeegaardSplittingSmallGenus"/> for functions to compute Heegaard splittings.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCSeriesBdHandleBody(3,9);;
 ## gap> list:=[[1..3],[4..9]];
 ## gap> SCIsHeegaardSplitting(c,list);
 ## gap> splitting:=SCHeegaardSplitting(c);
 ## gap> SCIsHeegaardSplitting(c,splitting[2]);                                         
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>

--- a/lib/highlySymmetricSurfaces.gi
+++ b/lib/highlySymmetricSurfaces.gi
@@ -6,10 +6,10 @@
 ## <Description>
 ## Returns the number of simplicial regular maps on the torus with <M>n</M> vertices, 
 ## cf. <Cite Key="Brehm08EquivMapsTorus"/> for details.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCNrRegularTorus(9);
 ## gap> SCNrRegularTorus(10);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -36,10 +36,10 @@ end);
 ## <Description>
 ## Returns the number of simplicial chiral maps on the torus with <M>n</M> vertices, 
 ## cf. <Cite Key="Brehm08EquivMapsTorus"/> for details.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCNrChiralTori(7);
 ## gap> SCNrChiralTori(343);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -116,10 +116,10 @@ end;
 ## Returns the equivarient triangulation of the torus <M>\{ 3,6 \}_{(p,q)}</M> with 
 ## fundamental domain <M>(p,q)</M> on the <M>2</M>-dimensional integer lattice. 
 ## See <Cite Key="Brehm08EquivMapsTorus"/> for details.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCSeriesSymmetricTorus(2,1);
 ## gap> SCFVector(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -378,11 +378,11 @@ end);
 ## Returns a list of regular triangulations of the torus with <M>n</M> vertices (the
 ## length of the list will be at most <M>1</M>).
 ## See <Cite Key="Brehm08EquivMapsTorus"/> for details.
-## <Example>
+## <Example><![CDATA[
 ## gap> cc:=SCRegularTorus(9);
 ## gap> g:=SCAutomorphismGroup(cc[1]);
 ## gap> SCNumFaces(cc[1],0)*12 = Size(g);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -419,10 +419,10 @@ end);
 ## <Description>
 ## Returns a list of chiral triangulations of the torus with <M>n</M> vertices.
 ## See <Cite Key="Brehm08EquivMapsTorus"/> for details.
-## <Example>
+## <Example><![CDATA[
 ## gap> cc:=SCChiralTori(91);
 ## gap> SCIsIsomorphic(cc[1],cc[2]);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -482,12 +482,12 @@ end);
 ## Use the <M>3</M>-tuples of the list together with <Ref Func="SCRegularMap"/> 
 ## to get the corresponding triangulations.
 ## <M>g</M>
-## <Example>
+## <Example><![CDATA[
 ## gap> ll:=SCRegularMaps(){[1..10]};
 ## gap> c:=SCRegularMap(ll[5][1],ll[5][2],ll[5][3]);
 ## gap> SCHomology(c);
 ## gap> SCGenerators(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -535,12 +535,12 @@ end);
 ## the classification of regular maps by Marston Conder <Cite Key="Conder09RegMapsOfBdChi"/>.
 ##
 ## Use <Ref Func="SCRegularMaps"/> to get a list of all regular maps available.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCRegularMaps(){[1..10]};
 ## gap> c:=SCRegularMap(7,7,true);
 ## gap> g:=SCAutomorphismGroup(c);
 ## gap> Size(g);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -3320,11 +3320,11 @@ end);
 ##
 ## Use the <M>2</M>-tuples of the list together with <Ref Func="SCChiralMap"/> 
 ## to get the corresponding triangulations.
-## <Example>
+## <Example><![CDATA[
 ## gap> ll:=SCChiralMaps();
 ## gap> c:=SCChiralMap(ll[18][1],ll[18][2]);
 ## gap> SCHomology(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -3352,11 +3352,11 @@ end);
 ##
 ## Use <Ref Func="SCChiralMaps"/> to get a list of all
 ## chiral maps available.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCChiralMaps();
 ## gap> c:=SCChiralMap(8,10);
 ## gap> c.Homology;
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>

--- a/lib/homology.gi
+++ b/lib/homology.gi
@@ -603,14 +603,14 @@ end;
 ## <Returns> a list upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Calculates the boundary of a given <Arg>simplex</Arg>. If the flag <Arg>orientation</Arg> is set to <K>true</K>, the function returns the boundary as a list of oriented simplices of the form [ ORIENTATION, SIMPLEX ], where ORIENTATION is either +1 or -1 and a value of +1 means that SIMPLEX is positively oriented and a value of -1 that SIMPLEX is negatively oriented. If <Arg>orientation</Arg> is set to <K>false</K>, an unoriented list of simplices is returned. 
-## <Example>
+## <Example><![CDATA[
 ## gap> SCBoundarySimplex([1..5],true);
 ## [ [ -1, [ 2, 3, 4, 5 ] ], [ 1, [ 1, 3, 4, 5 ] ], [ -1, [ 1, 2, 4, 5 ] ], 
 ##   [ 1, [ 1, 2, 3, 5 ] ], [ -1, [ 1, 2, 3, 4 ] ] ]
 ## gap> SCBoundarySimplex([1..5],false);
 ## [ [ 2, 3, 4, 5 ], [ 1, 3, 4, 5 ], [ 1, 2, 4, 5 ], [ 1, 2, 3, 5 ], 
 ##   [ 1, 2, 3, 4 ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -634,7 +634,7 @@ end);
 ## <Returns> a rectangular matrix  upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Calculates the matrix of the boundary operator <M>\partial_{<Arg>k+1</Arg>}</M> of a simplicial complex <Arg>complex</Arg>. Note that each column contains the boundaries of a <Arg>k</Arg><M>+1</M>-simplex as a list of oriented <Arg>k</Arg>-simplices and that the matrix is stored as a list of row vectors (as usual in GAP).
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCFromFacets([[1,2,3],[1,2,6],[1,3,5],[1,4,5],[1,4,6],\
 ##                       [2,3,4],[2,4,5],[2,5,6],[3,4,6],[3,5,6]]);;
 ## gap> mat:=SCBoundaryOperatorMatrix(c,1);
@@ -644,7 +644,7 @@ end);
 ##   [ 0, 0, -1, 0, 0, 0, -1, 0, 0, -1, 0, 0, 1, 1, 0 ], 
 ##   [ 0, 0, 0, -1, 0, 0, 0, -1, 0, 0, -1, 0, -1, 0, 1 ], 
 ##   [ 0, 0, 0, 0, -1, 0, 0, 0, -1, 0, 0, -1, 0, -1, -1 ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -697,7 +697,7 @@ end);
 ## <Returns> a rectangular matrix upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Calculates the matrix of the coboundary operator <M>d^{<Arg>k+1</Arg>}</M> as a list of row vectors.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCFromFacets([[1,2,3],[1,2,6],[1,3,5],[1,4,5],[1,4,6],\
 ##                       [2,3,4],[2,4,5],[2,5,6],[3,4,6],[3,5,6]]);
 ## gap> mat:=SCCoboundaryOperatorMatrix(c,1);
@@ -711,7 +711,7 @@ end);
 ##   [ 0, 0, 0, 0, 0, 0, 0, -1, 1, 0, 0, 0, 0, 0, -1 ], 
 ##   [ 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 0, 1, 0, -1, 0 ], 
 ##   [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -1, 1, 0, 0, -1 ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -744,14 +744,14 @@ end);
 ## <Returns> a list of pairs of the form <C>[ integer, list of linear combinations of simplices ]</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Calculates a set of basis elements for the <Arg>k</Arg>-dimensional homology group (with integer coefficients) of a simplicial complex <Arg>complex</Arg>. The entries of the returned list are of the form [ MODULUS, [ BASEELM1, BASEELM2, ...] ], where the value MODULUS is 1 for the basis elements of the free part of the <Arg>k</Arg>-th homology group and <M>q\geq 2</M> for the basis elements of the <M>q</M>-torsion part. In contrast to the function <Ref Meth="SCHomologyBasisAsSimplices" /> the basis elements are stored as lists of coefficient-index pairs referring to the simplices of the complex, i.e. a basis element of the form <M>[ [ \lambda_1, i], [\lambda_2, j], \dots ] \dots</M> encodes the linear combination of simplices of the form <M>\lambda_1*\Delta_1+\lambda_2*\Delta_2</M> with <M>\Delta_1</M>=<C>SCSkel(complex,k)[i]</C>, <M>\Delta_2</M>=<C>SCSkel(complex,k)[j]</C> and so on.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("(S^2xS^1)#RP^3");
 ## [ [ 237, "(S^2xS^1)#RP^3" ] ]
 ## gap> c:=SCLib.Load(last[1][1]);;
 ## gap> SCHomologyBasis(c,1);
 ## [ [ 1, [ [ 1, 12 ], [ -1, 7 ], [ 1, 1 ] ] ], 
 ##   [ 2, [ [ 1, 68 ], [ -1, 69 ], [ -1, 71 ], [ 2, 72 ], [ -2, 73 ] ] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -791,7 +791,7 @@ end);
 ## <Returns> a list of pairs of the form <C>[ integer, list of linear combinations of simplices ]</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Calculates a set of basis elements for the <Arg>k</Arg>-dimensional cohomology group (with integer coefficients) of a simplicial complex <Arg>complex</Arg>. The entries of the returned list are of the form [ MODULUS, [ BASEELM1, BASEELM2, ...] ], where the value MODULUS is 1 for the basis elements of the free part of the <Arg>k</Arg>-th homology group and <M>q\geq 2</M> for the basis elements of the <M>q</M>-torsion part. In contrast to the function <Ref Meth="SCCohomologyBasisAsSimplices" /> the basis elements are stored as lists of coefficient-index pairs referring to the linear forms dual to the simplices in the <M>k</M>-th cochain complex of <Arg>complex</Arg>, i.e. a basis element of the form <M>[ [ \lambda_1, i], [\lambda_2, j], \dots ] \dots</M> encodes the linear combination of simplices (or their dual linear forms in the corresponding cochain complex) of the form <M>\lambda_1*\Delta_1+\lambda_2*\Delta_2</M> with <M>\Delta_1</M>=<C>SCSkel(complex,k)[i]</C>, <M>\Delta_2</M>=<C>SCSkel(complex,k)[j]</C> and so on.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("SU(3)/SO(3)");   
 ## [ [ 219, "SU(3)/SO(3) (VT)" ], [ 477, "SU(3)/SO(3) (VT)" ], 
 ##   [ 484, "SU(3)/SO(3) (VT)" ], [ 486, "SU(3)/SO(3) (VT)" ] ]
@@ -817,7 +817,7 @@ end);
 ##           [ -3, 504 ], [ 9, 505 ], [ 9, 512 ], [ 9, 515 ], [ 6, 519 ], 
 ##           [ 18, 521 ], [ -15, 523 ], [ 9, 524 ], [ -3, 525 ], [ 18, 527 ], 
 ##           [ -18, 528 ], [ 6, 529 ], [ 6, 531 ], [ 12, 532 ] ] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -872,7 +872,7 @@ end;
 ## <Returns> a list of pairs of the form <C>[ integer, list of linear combinations of simplices ]</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Calculates a set of basis elements for the <Arg>k</Arg>-dimensional homology group (with integer coefficients) of a simplicial complex <Arg>complex</Arg>. The entries of the returned list are of the form [ MODULUS, [ BASEELM1, BASEELM2, ...] ], where the value MODULUS is 1 for the basis elements of the free part of the <Arg>k</Arg>-th homology group and <M>q\geq 2</M> for the basis elements of the <M>q</M>-torsion part. In contrast to the function <Ref Meth="SCHomologyBasis" /> the basis elements are stored as lists of coefficient-simplex pairs, i.e. a basis element of the form <M>[ [ \lambda_1, \Delta_1], [\lambda_2, \Delta_2], \dots ]</M> encodes the linear combination of simplices of the form <M>\lambda_1*\Delta_1+\lambda_2*\Delta_2 + \dots</M>.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("(S^2xS^1)#RP^3");
 ## [ [ 237, "(S^2xS^1)#RP^3" ] ]
 ## gap> c:=SCLib.Load(last[1][1]);;
@@ -880,7 +880,7 @@ end;
 ## [ [ 1, [ [ 1, [ 2, 8 ] ], [ -1, [ 1, 8 ] ], [ 1, [ 1, 2 ] ] ] ], 
 ##   [ 2, [ [ 1, [ 11, 12 ] ], [ -1, [ 11, 13 ] ], [ -1, [ 12, 13 ] ], 
 ##          [ 2, [ 12, 14 ] ], [ -2, [ 13, 14 ] ] ] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -916,7 +916,7 @@ end);
 ## <Returns> a list of pars of the form <C>[ integer, linear combination of simplices ]</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Calculates a set of basis elements for the <Arg>k</Arg>-dimensional cohomology group (with integer coefficients) of a simplicial complex <Arg>complex</Arg>. The entries of the returned list are of the form [ MODULUS, [ BASEELM1, BASEELM2, ...] ], where the value MODULUS is 1 for the basis elements of the free part of the <Arg>k</Arg>-th homology group and <M>q\geq 2</M> for the basis elements of the <M>q</M>-torsion part. In contrast to the function <Ref Meth="SCCohomologyBasis" /> the basis elements are stored as lists of coefficient-simplex pairs referring to the linear forms dual to the simplices in the <M>k</M>-th cochain complex of <Arg>complex</Arg>, i.e. a basis element of the form <M>[ [ \lambda_1, \Delta_i], [\lambda_2, \Delta_j], \dots ] \dots</M> encodes the linear combination of simplices (or their dual linear forms in the corresponding cochain complex) of the form <M>\lambda_1*\Delta_1+\lambda_2*\Delta_2 + \dots</M>.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("SU(3)/SO(3)");   
 ## [ [ 219, "SU(3)/SO(3) (VT)" ], [ 477, "SU(3)/SO(3) (VT)" ], 
 ##   [ 484, "SU(3)/SO(3) (VT)" ], [ 486, "SU(3)/SO(3) (VT)" ] ]
@@ -959,7 +959,7 @@ end);
 ##          [ -3, [ 8, 9, 11, 12 ] ], [ 18, [ 8, 10, 11, 12 ] ], 
 ##          [ -18, [ 8, 10, 12, 13 ] ], [ 6, [ 9, 10, 11, 12 ] ], 
 ##          [ 6, [ 9, 10, 12, 13 ] ], [ 12, [ 9, 11, 12, 13 ] ] ] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -997,11 +997,11 @@ end);
 ## This function computes the reduced simplicial homology with integer coefficients of a given simplicial complex <Arg>complex</Arg> with integer coefficients. It uses the algorithm described in <Cite Key="Desbrun08DiscDiffFormCompModel"/>. <P/>
 ## The output is a list of homology groups of the form <M>[H_0,....,H_d]</M>, where <M>d</M> is the dimension of <Arg>complex</Arg>. The format of the homology groups <M>H_i</M> is given in terms of their maximal cyclic subgroups, i.e. a homology group <M>H_i\cong \mathbb{Z}^f + \mathbb{Z} / t_1 \mathbb{Z} \times \dots \times \mathbb{Z} / t_n \mathbb{Z}</M> is returned in form of a list <M>[ f, [t_1,...,t_n] ]</M>, where <M>f</M> is the (integer) free part of <M>H_i</M> and <M>t_i</M> denotes the torsion parts of <M>H_i</M> ordered in weakly incresing size. See also <Ref Meth="SCHomology"/> and
 ## <Ref Func="SCHomologyClassic" />.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCSurface(1,false);;
 ## gap> SCHomologyInternal(c);
 ## [ [ 0, [  ] ], [ 0, [ 2 ] ], [ 0, [  ] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1042,12 +1042,12 @@ end);
 ## <Description>
 ## This function computes the simplicial cohomology groups of a given simplicial complex <Arg>complex</Arg> with integer coefficients. It uses the algorithm described in <Cite Key="Desbrun08DiscDiffFormCompModel"/>.<P/>
 ## The output is a list of cohomology groups of the form <M>[H^0,....,H^d]</M>, where <M>d</M> is the dimension of <Arg>complex</Arg>. The format of the cohomology groups <M>H^i</M> is given in terms of their maximal cyclic subgroups, i.e. a cohomology group <M>H^i\cong \mathbb{Z}^f + \mathbb{Z} / t_1 \mathbb{Z} \times \dots \times \mathbb{Z} / t_n \mathbb{Z}</M> is returned in form of a list <M>[ f, [t_1,...,t_n] ]</M>, where <M>f</M> is the (integer) free part of <M>H^i</M> and <M>t_i</M> denotes the torsion parts of <M>H^i</M> ordered in weakly increasing size.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCFromFacets([[1,2,3],[1,2,6],[1,3,5],[1,4,5],[1,4,6],
 ##                       [2,3,4],[2,4,5],[2,5,6],[3,4,6],[3,5,6]]);
 ## gap> SCCohomology(c);
 ## [ [ 1, [  ] ], [ 0, [  ] ], [ 0, [ 2 ] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1080,7 +1080,7 @@ end);
 ## where <M>\sigma</M> is a <M>p + q</M>-simplex and <M>\iota_S</M>, <M>S \subset \{0,1,...,p+q \}</M> is the canonical embedding of the simplex spanned by <M>S</M> into the <M>(p + q)</M>-standard simplex.<P/>
 ## <M>\sigma \circ \iota_{0,1, ..., p}</M> is called the <M>p</M>-th front face and <M>\sigma \circ \iota_{p, p+1, ..., p + q}</M> is the <M>q</M>-th back face of <M>\sigma</M>, respectively.<P/>
 ## Note that this function only computes the cup product in the case that <Arg>complex</Arg> is an orientable weak pseudomanifold of dimension <M>2k</M> and <M>p = q = k</M>. Furthermore, <Arg>complex</Arg> must be given in standard labeling, with sorted facet list and <Arg>cocylce1</Arg> and <Arg>cocylce2</Arg> must be given in simplex notation and labeled accordingly. Note that the latter condition is usually fulfilled in case the cocycles were computed using <Ref Meth="SCCohomologyBasisAsSimplices"/>.  
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("K3");
 ## [ [ 520, "K3_16" ], [ 539, "K3_17" ] ]
 ## gap> c:=SCLib.Load(last[1][1]);;                                     
@@ -1090,7 +1090,7 @@ end);
 ## gap> SCCupProduct(c,basis[1][2],basis[2][2]);
 ## [ [ -1, [ 1, 2, 4, 7, 11 ] ], [ -1, [ 1, 2, 4, 7, 15 ] ], 
 ##   [ -1, [ 2, 3, 4, 5, 9 ] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1165,7 +1165,7 @@ end);
 ## For <M>2k</M>-dimensional orientable manifolds <M>M</M> the cup product (see <Ref Meth="SCCupProduct"/>) defines a bilinear form <P/>
 ## H<M>^k ( M ) \times </M>H<M>^k ( M ) \to </M>H<M>^{2k} (M), (a,b) \mapsto a \cup b </M><P/>
 ## called the intersection form of <M>M</M>. This function returns the intersection form of an orientable combinatorial <M>2k</M>-manifold <Arg>complex</Arg> in form of a matrix <C>mat</C> with respect to the basis of  H<M>^k ( </M><Arg>complex</Arg>M<M>)</M> computed by <Ref Meth="SCCohomologyBasisAsSimplices"/>. The matrix entry <C>mat[i][j]</C> equals the intersection number of the <C>i</C>-th base element with the <C>j</C>-th base element of H<M>^k ( </M><Arg>complex</Arg>M<M>)</M>. 
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("CP^2");       
 ## [ [ 16, "CP^2 (VT)" ], [ 96, "CP^2#-CP^2" ], 
 ##   [ 97, "CP^2#CP^2" ], [ 185, "CP^2#(S^2xS^2)" ], 
@@ -1182,7 +1182,7 @@ end);
 ## gap> PrintArray(q2);
 ## [ [   1,   0 ],
 ##   [   0,  -1 ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1253,7 +1253,7 @@ end);
 ## <Returns> <C>0</C> or <C>1</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the parity of the intersection form of a combinatorial manifold <Arg>complex</Arg> (see <Ref Meth="SCIntersectionForm"/>). If the intersection for is even (i. e. all diagonal entries are even numbers) <C>0</C> is returned, otherwise <C>1</C> is returned.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("S^2xS^2");;
 ## gap> c:=SCLib.Load(last[1][1]);;    
 ## gap> SCIntersectionFormParity(c);
@@ -1262,7 +1262,7 @@ end);
 ## gap> c:=SCLib.Load(last[1][1]);; 
 ## gap> SCIntersectionFormParity(c);
 ## 1
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1307,7 +1307,7 @@ end);
 ## <Returns> an integer upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Returns the dimensionality of the intersection form of a combinatorial manifold <Arg>complex</Arg>, i. e. the length of a minimal generating set of H<M>^k (M)</M> (where <M>2k</M> is the dimension of <Arg>complex</Arg>). See <Ref Meth="SCIntersectionForm"/> for further details.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("CP^2");;
 ## gap> c:=SCLib.Load(last[1][1]);; 
 ## gap> SCIntersectionFormParity(c);
@@ -1319,7 +1319,7 @@ end);
 ## gap> d:=SCConnectedProduct(c,10);;
 ## gap> SCIntersectionFormDimensionality(d);
 ## 10
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1357,7 +1357,7 @@ end);
 ## <Description>
 ## Computes the dimensionality (see <Ref Meth="SCIntersectionFormDimensionality"/>) and the signature of the intersection form of a combinatorial manifold <Arg>complex</Arg> as a <M>3</M>-tuple that contains the dimensionality in the first entry and the number of positive / negative eigenvalues in the second and third entry. See <Ref Meth="SCIntersectionForm"/> for further details.<P/>
 ## Internally calls the &GAP;-functions <C>Matrix_CharacteristicPolynomialSameField</C> and <C>CoefficientsOfLaurentPolynomial</C> to compute the number of positive / negative eigenvalues of the intersection form. 
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("CP^2");;
 ## gap> c:=SCLib.Load(last[1][1]);;
 ## gap> SCIntersectionFormParity(c);
@@ -1372,7 +1372,7 @@ end);
 ## gap> d:=SCConnectedSumMinus(c,c);;
 ## gap> SCIntersectionFormSignature(d);
 ## [ 2, 0, 2 ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>

--- a/lib/io.gi
+++ b/lib/io.gi
@@ -720,13 +720,13 @@ end;
 ## <C>IO_Pickle</C>) from a file specified in <Arg>filename</Arg> (as string). 
 ## If <Arg>filename</Arg> does not end in <C>.scb</C>, this suffix is 
 ## appended to the file name.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(3);;
 ## gap> SCSave(c,"/tmp/bddelta3");
 ## true
 ## gap> d:=SCLoad("/tmp/bddelta3");
 ## gap> c=d;
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -788,13 +788,13 @@ end);
 ## Loads a simplicial complex stored in XML format from a file specified in 
 ## <Arg>filename</Arg> (as string). If <Arg>filename</Arg> does not end in 
 ## <C>.sc</C>, this suffix is appended to the file name.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(3);;
 ## gap> SCSaveXML(c,"/tmp/bddelta3");
 ## true
 ## gap> d:=SCLoadXML("/tmp/bddelta3");
 ## gap> c=d;
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -842,11 +842,11 @@ end);
 ## Saves a simplicial complex in a binary format (using <C>IO_Pickle</C>) to 
 ## a file specified in <Arg>filename</Arg> (as string). If <Arg>filename</Arg> 
 ## does not end in <C>.scb</C>, this suffix is appended to the file name.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(3);;
 ## gap> SCSave(c,"/tmp/bddelta3");
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -902,11 +902,11 @@ end);
 ## Saves a simplicial complex <Arg>complex</Arg> to a file specified by 
 ## <Arg>filename</Arg> (as string) in XML format. If <Arg>filename</Arg> does 
 ## not end in <C>.sc</C>, this suffix is appended to the file name.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(3);;
 ## gap> SCSaveXML(c,"/tmp/bddelta3");
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -994,11 +994,11 @@ end;
 ## <M>v_1, \dots ,v_n</M> where <M>n</M> is the number of vertices of 
 ## <Arg>complex</Arg>. If <Arg>complex</Arg> has more than <M>26</M> 
 ## vertices, the argument <Arg>alphalabels</Arg> is ignored. 
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdCrossPolytope(4);;
 ## gap> SCExportMacaulay2(c,Integers,"/tmp/bdbeta4.m2");
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1100,11 +1100,11 @@ end);
 ## <Arg>complex</Arg> in <C>polymake</C> format to a file specified by 
 ## <Arg>filename</Arg>. Currently, only the export in the format of 
 ## <C>polymake</C> version 2.3 is supported. 
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdCrossPolytope(4);;
 ## gap> SCExportPolymake(c,"/tmp/bdbeta4.poly");
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1154,11 +1154,11 @@ end);
 ## Exports the gluings of the tetrahedra of a given combinatorial 
 ## <M>3</M>-manifold <Arg>complex</Arg> in a format compatible with Matveev's 
 ## <M>3</M>-manifold software <C>Recognizer</C>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdCrossPolytope(4);;
 ## gap> SCExportRecognizer(c,"/tmp/bdbeta4.mv");
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1235,11 +1235,11 @@ end);
 ## <Arg>coords</Arg> as list of <M>3</M>-tuples) or as string of the form 
 ## <C>"x.x y.y z.z"</C> with decimal numbers <C>x.x</C>, <C>y.y</C>, 
 ## <C>z.z</C> for the three coordinates (i.e. <C>"1.0 0.0 0.0"</C>).
-## <Example>
+## <Example><![CDATA[
 ## gap> coords:=[[1,0,0],[0,1,0],[0,0,1]];;
 ## gap> SCExportJavaView(SCBdSimplex(2),"/tmp/triangle.jvx",coords);
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1420,10 +1420,10 @@ end);
 ## specified by <Arg>filename</Arg>. The argument <Arg>itemsperline</Arg> 
 ## specifies how many columns the exported table should have. The faces are 
 ## exported in the format <M>\langle v_1,\dots,v_k \rangle</M>.  
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(5);;
 ## gap> SCExportLatexTable(c,"/tmp/bd5simplex.tex",5);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1502,12 +1502,12 @@ end);
 ## Imports the facet list of a <C>topaz</C> <C>polymake</C> file specified by 
 ## <Arg>filename</Arg> (discarding any vertex labels) and creates a 
 ## simplicial complex object from these facets.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdCrossPolytope(4);;
 ## gap> SCExportPolymake(c,"/tmp/bdbeta4.poly");
 ## gap> d:=SCImportPolymake("/tmp/bdbeta4.poly");
 ## gap> c=d;
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1749,12 +1749,12 @@ rec(
 ## Exports the facet list and orientability of a given combinatorial 
 ## <M>3</M>-pseudomanifold <Arg>complex</Arg> in <C>SnapPy</C> format to a 
 ## file specified by <Arg>filename</Arg>.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByAttribute("Dim=3 and F=[8,28,56,28]");
 ## gap> c:=SCLib.Load(last[1][1]);;
 ## gap> SCExportSnapPy(c,"/tmp/M38.tri");
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>

--- a/lib/isosig.gi
+++ b/lib/isosig.gi
@@ -17,10 +17,10 @@
 ## Computes the isomorphism signature of a closed, strongly connected weak 
 ## pseudomanifold. The isomorphism signature is stored as an attribute of the
 ## complex.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCSeriesBdHandleBody(3,9);;
 ## gap> s:=SCExportIsoSig(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -182,11 +182,11 @@ end);
 ## Computes one string representation of a closed and strongly connected weak 
 ## pseudomanifold. Compare <Ref Func="SCExportIsoSig" />, which returns the
 ## lexicographically minimal string representation.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCSeriesBdHandleBody(3,9);;
 ## gap> s:=SCExportToString(c); time;
 ## gap> s:=SCExportIsoSig(c); time;
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -331,17 +331,17 @@ end);
 ## <Description>
 ## Computes a simplicial complex from its isomorphism signature. If a file with
 ## isomorphism signatures is provided a list of all complexes is returned.
-## <Example>
+## <Example><![CDATA[
 ## gap> s:="deeee";;
 ## gap> c:=SCFromIsoSig(s);;
 ## gap> SCIsIsomorphic(c,SCBdSimplex(4));
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> s:="deeee";;
 ## gap> PrintTo("tmp.txt",s,"\n");;
 ## gap> cc:=SCFromIsoSig("tmp.txt");
 ## gap> cc[1].F;
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>

--- a/lib/labelops.gi
+++ b/lib/labelops.gi
@@ -17,14 +17,14 @@
 ## <Returns> a string upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Returns the name of a simplicial complex <Arg>complex</Arg>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(5);;
 ## gap> SCName(c);
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> c:=SC([[1,2],[2,3],[3,1]]);;
 ## gap> SCName(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -47,7 +47,7 @@ end);
 ## <Returns> <K>true</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Renames a polyhedral complex. The argument <Arg>name</Arg> has to be given in form of a string.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(5);;
 ## gap> SCName(c);
 ## "S^4_6"
@@ -55,7 +55,7 @@ end);
 ## true
 ## gap> SCName(c);
 ## "mySphere"
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -82,12 +82,12 @@ end);
 ## <Returns> a string upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Returns a literature reference of a polyhedral complex <Arg>complex</Arg>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCLib.Load(253);;
 ## gap> SCReference(c);
 ## gap> c:=SC([[1,2],[2,3],[3,1]]);;
 ## gap> SCReference(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -110,13 +110,13 @@ end);
 ## <Returns> <K>true</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Sets the literature reference of a polyhedral complex. The argument <Arg>ref</Arg> has to be given in form of a string.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(5);;
 ## gap> SCReference(c);
 ## gap> SCSetReference(c,"my 5-sphere in my cool paper");
 ## true
 ## gap> SCReference(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -142,11 +142,11 @@ end);
 ## <Returns> a string upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Returns the date stamp of a simplicial complex <Arg>complex</Arg>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SC([[1,2],[2,3],[3,1]]);;
 ## gap> SCSetDate(c,"2011-11-11");
 ## gap> SCDate(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -169,13 +169,13 @@ end);
 ## <Returns> <K>true</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Sets the date stamp of a simplicial complex. The argument <Arg>date</Arg> has to be given in form of a string.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(5);;
 ## gap> SCDate(c);
 ## gap> SCSetDate(c,"2011-11-11");
 ## true
 ## gap> SCDate(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -202,11 +202,11 @@ end);
 ## <Returns>a list of vertex labels of <Arg>complex</Arg> (a list of integers, short lists, characters, short strings, ...) upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Returns the vertex labels of <Arg>complex</Arg> as a list. This is a synonym of <Ref Meth="SCVertices"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCFromFacets(Combinations(["a","b","c","d"],3));;
 ## gap> SCLabels(c);
 ## [ "a", "b", "c", "d" ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -219,7 +219,7 @@ end);
 ## <Returns> <K>true</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Maps vertex labels <M>v_1 , \ldots , v_n</M> of <Arg>complex</Arg> to <M>[1 , \ldots , n]</M>. Internally the property "SCVertices" is replaced by <M>[1 , \ldots , n]</M>.
-## <Example>
+## <Example><![CDATA[
 ## gap> list:=SCLib.SearchByAttribute("F[1]=12");; 
 ## gap> c:=SCLib.Load(list[1][1]);;
 ## gap> SCRelabel(c,[4..15]);
@@ -230,7 +230,7 @@ end);
 ## true
 ## gap> SCLabels(c);
 ## [ 1 .. 12 ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -266,7 +266,7 @@ end);
 ## <Arg>maptable</Arg> has to be a list of length <M>n</M> where <M>n</M> is the number of vertices of <Arg>complex</Arg>. The function maps the <M>i</M>-th entry of <Arg>maptable</Arg> to the <M>i</M>-th entry of the current vertex labels. If <Arg>complex</Arg> has the standard vertex labeling <M>[1, \ldots , n]</M> the vertex label <M>i</M> is mapped to <Arg>maptable[i]</Arg>.<P/>
 ## Note that the elements of <Arg>maptable</Arg> must admit a total ordering. Hence, following Section 4.11 of the &GAP; manual, they must be members of one of the following families: rationals <C>IsRat</C>, cyclotomics <C>IsCyclotomic</C>, finite field elements <C>IsFFE</C>, permutations <C>IsPerm</C>, booleans <C>IsBool</C>, characters <C>IsChar</C> and lists (strings) <C>IsList</C>.<P/>
 ## Internally the property ``SCVertices'' of <Arg>complex</Arg> is replaced by <Arg>maptable.</Arg><P/>
-## <Example>
+## <Example><![CDATA[
 ## gap> list:=SCLib.SearchByAttribute("F[1]=12");; 
 ## gap> c:=SCLib.Load(list[1][1]);;
 ## gap> SCVertices(c);
@@ -275,7 +275,7 @@ end);
 ## true
 ## gap> SCLabels(c);
 ## [ "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l" ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -313,14 +313,14 @@ end);
 ## <Description>
 ## Permutes vertex labels of a single pair of vertices. <Arg>pair</Arg> has to be a list of length <M>2</M> and a sublist of the property ``SCVertices''.<P/>
 ## The function is equivalent to <Ref Meth="SCRelabel"/> with <Arg>maptable</Arg> <M>= [ SCVertices[1] , \ldots , SCVertices[j] , \ldots , SCVertices[i] , \dots , SCVertices[n]]</M> if <Arg>pair</Arg> <M>= [ SCVertices[j] , SCVertices[i]]</M>, <M>j \leq i</M>, <M>j \neq i</M>.<P/>
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(3);;
 ## gap> SCVertices(c);
 ## [ 1, 2, 3, 4 ]
 ## gap> SCRelabelTransposition(c,[1,2]);;
 ## gap> SCLabels(c);
 ## [ 2, 1, 3, 4 ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -357,18 +357,18 @@ end);
 ## <Returns>vertex label of <Arg>complex</Arg> (an integer, a short list, a character, a short string) upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## The maximum over all vertex labels is determined by the &GAP; function <C>MaximumList</C>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(3);;
 ## gap> SCRelabel(c,[10,100,100000,3500]);;
 ## gap> SCLabelMax(c);
 ## 100000
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(3);;
 ## gap> SCRelabel(c,["a","bbb",5,[1,1]]);;
 ## gap> SCLabelMax(c);
 ## "bbb"
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -402,18 +402,18 @@ end);
 ## <Returns>vertex label of <Arg>complex</Arg> (an integer, a short list, a character, a short string) upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## The minimum over all vertex labels is determined by the &GAP; function <C>MinimumList</C>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(3);;
 ## gap> SCRelabel(c,[10,100,100000,3500]);;
 ## gap> SCLabelMin(c);
 ## 10
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(3);;
 ## gap> SCRelabel(c,["a","bbb",5,[1,1]]);;
 ## gap> SCLabelMin(c);
 ## 5
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -446,12 +446,12 @@ end);
 ## <Returns> a list upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the standard labeling of <Arg>face</Arg> in <Arg>complex</Arg>. 
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(3);;
 ## gap> SCRelabel(c,["a","bbb",5,[1,1]]);;
 ## gap> SCUnlabelFace(c,["a","bbb",5]);
 ## [ 1, 2, 3 ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>

--- a/lib/lib.gi
+++ b/lib/lib.gi
@@ -16,10 +16,10 @@
 ## <Returns><K>true</K> or <K>false</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Filter for the category of a library repository <C>SCIsLibRepository</C> used by the <Package>simpcomp</Package> library. The category <C>SCLibRepository</C> is derived from the category <C>SCPropertyObject</C>.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCIsLibRepository(SCLib); #the global library is stored in SCLib
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -139,12 +139,12 @@ end);
 ## <Returns><K>true</K> or <K>false</K> upon succes, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Returns <K>true</K> when a given library repository <Arg>repository</Arg> is in loaded state. This means that the directory of this repository is accessible and a repository index file for this repository exists in the repositories' path. If this is not the case <K>false</K> is returned.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLibIsLoaded(SCLib);
 ## true
 ## gap> SCLib.IsLoaded;
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -165,10 +165,10 @@ end);
 ## <Returns> integer upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Returns the number of complexes contained in the given repository <Arg>repository</Arg>. Fails if the library repository was not previously loaded with <C>SCLibInit</C>.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLibSize(SCLib); #SCLib is the repository of the global library
 ## 7648
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -200,12 +200,12 @@ end);
 ## <Returns>simplicial complex of type <C>SCSimplicialComplex</C>, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Loads a simplicial complex from the given library repository <Arg>repository</Arg> by its id <C>id</C>. The id is repository specific and ranges from 1 to N where N are the number of complexes currently in the repository (this number can be determined by <C>SCLibSize</C>). If the id is not valid (non-positive or bigger than maximal id), an error is signalled. Ids in the global library repository of <Package>simpcomp</Package>, <C>SCLib</C>, are sorted by in ascending order by the f-vector of the complexes. 
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("S^2~S^1"){[1..3]};
 ## gap> id:=last[1][1];;
 ## gap> SCLibLoad(SCLib,id);
 ## gap> SCLib.Load(id);; #the same operation in alternative syntax
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -438,7 +438,7 @@ end;
 ## <Returns>library repository of type <C>SCLibRepository</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Recreates the index of a given repository (either via a repository object or a base path of a repository <Arg>repository</Arg>) by scanning the base path for all <C>.sc</C> files containing simplicial complexes of the repository. Returns a repository object with the newly created index on success or <K>fail</K> in case of an error. The optional boolean argument <Arg>recalc</Arg> forces <Package>simpcomp</Package> to recompute all the indexed properties (such as f-vector, homology, etc.) of the simplicial complexes in the repository if set to <K>true</K>. 
-## <Example>
+## <Example><![CDATA[
 ## gap> myRepository:=SCLibInit("/tmp/repository");;
 ## #I  SCLibInit: made directory "/tmp/repository/" for user library.
 ## #I  SCIntFunc.SCLibInit: index not found -- trying to reconstruct it.
@@ -454,7 +454,7 @@ end;
 ## Loaded=true
 ## Path="/tmp/repository/"
 ##]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -584,13 +584,13 @@ end);
 ## <Returns> list of entries of the form <C>[ integer, string ]</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Returns a list with entries of the form <C>[ ID, NAME ]</C> of all the complexes in the given repository <Arg>repository</Arg> of type <C>SCIsLibRepository</C>. 
-## <Example>
+## <Example><![CDATA[
 ## gap> all:=SCLibAllComplexes(SCLib);;
 ## gap> all[1];
 ## [ 1, "Moebius Strip" ]
 ## gap> Length(all);
 ## 7648
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -620,7 +620,7 @@ end);
 ## <Returns><K>true</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Adds a given simplicial complex <Arg>complex</Arg> to a given repository <Arg>repository</Arg> of type <C>SCIsLibRepository</C>. <Arg>complex</Arg> is saved to a file with suffix <C>.sc</C> in the repositories base path, where the file name is either formed from the optional argument <Arg>name</Arg> and the current time or taken from the name of the complex, if it is named. 
-## <Example>
+## <Example><![CDATA[
 ## gap> info:=InfoLevel(InfoSimpcomp);;
 ## gap> SCInfoLevel(0);;
 ## gap> myRepository:=SCLibInit("/tmp/repository");
@@ -636,7 +636,7 @@ end);
 ## gap> complex2:=SCBdCrossPolytope(4);;
 ## gap> myRepository.Add(complex2);; # alternative syntax
 ## gap> SCInfoLevel(info);;
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -733,7 +733,7 @@ end);
 ## <Returns><K>true</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Deletes the simplicial complex with the given id <Arg>id</Arg> from the given repository <Arg>repository</Arg>. Apart from deleting the complexes' index entry, the associated <C>.sc</C> file is also deleted.
-## <Example>
+## <Example><![CDATA[
 ## gap> myRepository:=SCLibInit("/tmp/repository");
 ## #I  SCLibInit: made directory "/tmp/repository/" for user library.
 ## #I  SCIntFunc.SCLibInit: index not found -- trying to reconstruct it.
@@ -742,7 +742,7 @@ end);
 ## gap> SCLibAdd(myRepository,SCSimplex(2));;
 ## gap> SCLibDelete(myRepository,1);
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -788,7 +788,7 @@ end);
 ## Completely empties a given repository <Arg>repository</Arg>. The index and all 
 ## simplicial complexes in this repository are deleted. The second argument, 
 ## <Arg>confirm</Arg>, must be the string <C>"yes"</C> in order to confirm the deletion. 
-## <Example>
+## <Example><![CDATA[
 ## gap> myRepository:=SCLibInit("/tmp/repository");;
 ## #I  SCLibInit: made directory "/tmp/repository/" for user library.
 ## #I  SCIntFunc.SCLibInit: index not found -- trying to reconstruct it.
@@ -798,7 +798,7 @@ end);
 ## #I  SCLibUpdate: rebuilding index for /home/effenbfx/testrepo/.
 ## #I  SCLibUpdate: rebuilding index done.
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -861,7 +861,7 @@ end;
 ## <Returns>A list of items of the form <C>[ integer, string ]</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Searches a given repository <Arg>repository</Arg> for complexes that contain the string <Arg>name</Arg> as a substring of their name attribute and returns a list of the complexes found with entries of the form <C>[ID, NAME]</C>. See <Ref Var="SCLib"/> for a naming convention used for the global library of <Package>simpcomp</Package>.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLibSearchByName(SCLib,"K3");
 ## [ [ 584, "K3 surface" ] ]
 ## gap> SCLib.SearchByName("K3"); #alternative syntax
@@ -869,7 +869,7 @@ end;
 ## gap> SCLib.SearchByName("S^4x"); #search for products with S^4
 ## [ [ 291, "S^4xS^1 (VT)" ], [ 340, "S^4xS^1 (VT)" ], [ 342, "S^4xS^1 (VT)" ], 
 ##   [ 571, "S^4xS^2" ], [ 627, "S^4xS^3" ], [ 655, "S^4xS^4" ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -893,14 +893,14 @@ end);
 ## <Returns>A list of items of the form <C>[ integer, string ]</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Searches a given repository <Arg>repository</Arg> for complexes for which the boolean expression <Arg>expr</Arg>, passed as string, evaluates to <K>true</K> and returns a list of complexes with entries of the form <C>[ID, NAME]</C> or <K>fail</K> upon error. The expression may use all &GAP; functions and can access all the indexed attributes of the complexes in the given repository for the query. The standard attributes are: Dim (Dimension), F (f-vector), G (g-vector), H (h-vector), Chi (Euler characteristic), Homology, Name, IsPM, IsManifold. See <C>SCLib</C> for the set of indexed attributes of the global library of <Package>simpcomp</Package>. 
-## <Example>
+## <Example><![CDATA[
 ## #search for all 3-neighborly complexes of dimension 4 in the global library
 ## gap> SCLibSearchByAttribute(SCLib,"Dim=4 and F[3]=Binomial(F[1],3)");
 ## [ [ 17, "CP^2 (VT)" ], [ 584, "K3 surface" ] ]
 ## # alternative syntax
 ## gap> SCLib.SearchByAttribute("Dim=4 and F[3]=Binomial(F[1],3)");
 ## [ [ 17, "CP^2 (VT)" ], [ 584, "K3 surface" ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1016,7 +1016,7 @@ end);
 ## <Returns>library repository of type <C>SCLibRepository</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Lets &GAP; print the status of a given library repository <Arg>repository</Arg>. <C>IndexAttributes</C> is the list of attributes indexed for this repository. If <C>CalculateIndexAttributes</C> is true, the index attributes for a complex added to the library are calculated automatically upon addition of the complex, otherwise this is left to the user and only pre-calculated attributes are indexed.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLibStatus(SCLib);
 ## [Simplicial complex library. Properties:
 ## CalculateIndexAttributes=true
@@ -1025,7 +1025,7 @@ end);
 ## Loaded=true
 ## Path="GAPROOT/pkg/simpcomp/complexes/"
 ##]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1053,11 +1053,11 @@ end);
 ## If <Arg>complex</Arg> is a combinatorial manifold of dimension <M>1</M> or <M>2</M> its topological type is computed, stored to the property <C>TopologicalType</C> and <Arg>complex</Arg> is returned.<P/>
 ##
 ## If no complexes with matching homology can be found, the empty set is returned.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCFromFacets([[1,2,3],[1,2,6],[1,3,5],[1,4,5],[1,4,6],
 ##                       [2,3,4],[2,4,5],[2,5,6],[3,4,6],[3,5,6]]);;
 ## gap> SCLibDetermineTopologicalType(c);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1198,7 +1198,7 @@ end);
 ## The global library repository of <Package>simpcomp</Package> is loaded automatically at startup and is stored in the variable <C>SCLib</C>. User repositories can be created by calling <C>SCLibInit</C> with a desired destination directory. Note that each repository must reside in a different path since otherwise data may get lost.  <P/>
 ## The function first tries to load the repository index for the given directory to rebuild it (by calling <C>SCLibUpdate</C>) if loading the index fails.
 ## The library index of a library repository is stored in its base path in the XML file <C>complexes.idx</C>, the complexes are stored in files with suffix <C>.sc</C>, also in XML format.
-## <Example>
+## <Example><![CDATA[
 ## gap> myRepository:=SCLibInit("/tmp/repository");
 ## #I  SCLibInit: made directory "/tmp/repository/" for user library.
 ## #I  SCIntFunc.SCLibInit: index not found -- trying to reconstruct it.
@@ -1211,7 +1211,7 @@ end);
 ## Loaded=true
 ## Path="/tmp/repository/"
 ##]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1284,7 +1284,7 @@ end;
 ## The global variable <C>SCLib</C> contains the library object of the global library of <Package>simpcomp</Package> through which the user can access the library. The path to the global library is <C>GAPROOT/pkg/simpcomp/complexes</C>.<P/>
 ##
 ## The naming convention in the global library is the following: complexes are usually named by their topological type. As usual, `<Alt Only="LaTeX"><![CDATA[	S\^{}d]]></Alt><Alt Not="LaTeX"><![CDATA[S^d]]></Alt>' denotes a <M>d</M>-sphere, `T' a torus, `x' the cartesian product, `<Alt Only="LaTeX"><![CDATA[\~{}]]></Alt><Alt Not="LaTeX"><![CDATA[~]]></Alt>' the twisted product and `<Alt Only="LaTeX"><![CDATA[\#]]></Alt><Alt Not="LaTeX"><![CDATA[#]]></Alt>' the connected sum. The Klein Bottle is denoted by `K' or `<Alt Only="LaTeX"><![CDATA[K\^{}2]]></Alt><Alt Not="LaTeX"><![CDATA[K^2]]></Alt>'.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib;
 ## [Simplicial complex library. Properties:
 ##  CalculateIndexAttributes=true
@@ -1304,7 +1304,7 @@ end;
 ##   [ 459, "S^4~S^1 (VT)" ], [ 460, "S^4~S^1 (VT)" ] ]
 ## gap> SCLib.Load(last[1][1]);          
 ## 
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>

--- a/lib/morse.gi
+++ b/lib/morse.gi
@@ -63,7 +63,7 @@ end;
 ## <M>(v_1 , \ldots v_n)</M> of all vertices  of <C>c</C> where <C>f</C> is 
 ## defined by <C>f</C><M>(v_i) = \frac{i-1}{n-1}</M>. The <M>i</M>-th entry 
 ## of the returned list denotes the multiplicity vector of vertex <M>v_i</M>.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("K3");      
 ## [ [ 520, "K3_16" ], [ 539, "K3_17" ] ]
 ## gap> c:=SCLib.Load(last[1][1]);;    
@@ -76,7 +76,7 @@ end;
 ##   [ 0, 0, 4, 0, 0 ], [ 0, 0, 1, 0, 0 ], [ 0, 0, 2, 0, 0 ], 
 ##   [ 0, 0, 1, 0, 0 ], [ 0, 0, 0, 0, 0 ], [ 0, 0, 0, 0, 0 ], 
 ##   [ 0, 0, 0, 0, 1 ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -136,7 +136,7 @@ end);
 ## Computes the number of critical points of each index of a rsl-function 
 ## <C>f</C> on a simplicial complex <C>c</C> as well as the total number of 
 ## critical points.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("K3");      
 ## [ [ 520, "K3_16" ], [ 539, "K3_17" ] ]
 ## gap> c:=SCLib.Load(last[1][1]);;    
@@ -144,7 +144,7 @@ end);
 ## [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 ]
 ## gap> SCMorseNumberOfCriticalPoints(c,f);
 ## [ 24, [ 1, 0, 22, 0, 1 ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -199,7 +199,7 @@ end);
 ## complex <C>c</C> or not. A rsl-function is said to be perfect, if it has 
 ## the minimum number of critical points, i. e. if the sum of its critical 
 ## points equals the sum of the Betti numbers of <C>c</C>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdCyclicPolytope(4,6);;
 ## gap> SCMinimalNonFaces(c);
 ## [ [  ], [  ], [ [ 1, 3, 5 ], [ 2, 4, 6 ] ] ]
@@ -207,7 +207,7 @@ end);
 ## true
 ## gap> SCMorseIsPerfect(c,[1,3,5,2,4,6]);   
 ## false
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -276,7 +276,7 @@ end);
 ## <M>(v_1 , v_2)</M> where <M>v_1 \in V_1</M> and <M>v_2 \in V_2</M>. They 
 ## represent the center points of the edges <M>\rangle v_1 , v_2 \langle </M> 
 ## defined by the intersection of <Arg>slicing</Arg> with <Arg>complex</Arg>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdCyclicPolytope(4,6);;
 ## gap> v:=SCVertices(c);
 ## [ 1, 2, 3, 4, 5, 6 ]
@@ -296,8 +296,8 @@ end);
 ##  TopologicalType="T^2"
 ## 
 ## /NormalSurface]
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(5);;
 ## gap> v:=SCVertices(c);
 ## [ 1, 2, 3, 4, 5, 6 ]
@@ -308,7 +308,7 @@ end);
 ##   [ [ 1, 2 ], [ 1, 4 ], [ 1, 6 ], [ 5, 2 ], [ 5, 4 ], [ 5, 6 ] ], 
 ##   [ [ 1, 4 ], [ 1, 6 ], [ 3, 4 ], [ 3, 6 ], [ 5, 4 ], [ 5, 6 ] ], 
 ##   [ [ 3, 2 ], [ 3, 4 ], [ 3, 6 ], [ 5, 2 ], [ 5, 4 ], [ 5, 6 ] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -410,7 +410,7 @@ end);
 ## <Ref Meth="SCAutomorphismGroup" />. In case it is <M>k</M>-transitive, the 
 ## complexity is reduced by the factor of <M>n \cdot (n-1) \cdot \dots \cdot 
 ## (n-k+1)</M>.
-## <Example>
+## <Example><![CDATA[
 ## gap> list:=SCLib.SearchByName("S^2~S^1 (VT)"){[1..9]};;
 ## gap> s2s1:=SCLib.Load(list[1][1]);
 ## gap> SCInfoLevel(2); # print information while running
@@ -428,8 +428,8 @@ end);
 ## #I  SCIsTight: processed 40000 of 40320 rsl-functions so far, all perfect.
 ## true
 ## 11217
-## </Example> 
-## <Example>
+## ]]></Example> 
+## <Example><![CDATA[
 ## gap> SCLib.SearchByAttribute("F[1] = 120");
 ## [ [ 648, "Bd(600-cell)" ] ]
 ## gap> id:=last[1][1];;
@@ -446,8 +446,8 @@ end);
 ##   113, 114, 115, 116, 117, 118, 119, 120 ], complex not tight.
 ## false
 ## 28
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> SCInfoLevel(0);
 ## gap> SCLib.SearchByName("K3");  
 ## [ [ 520, "K3_16" ], [ 539, "K3_17" ] ]
@@ -458,8 +458,8 @@ end);
 ## gap> c.IsTight;                 
 ## #I  SCIsTight: complex is (k+1)-neighborly 2k-manifold and thus tight.
 ## true
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> SCInfoLevel(1);
 ## gap> dc:=[ [ 1, 1, 1, 1, 45 ], [ 1, 2, 1, 27, 18 ], [ 1, 27, 9, 9, 3 ], 
 ## > [ 4, 7, 20, 9, 9 ], [ 9, 9, 11, 9, 11 ], [ 6, 9, 9, 17, 8 ], 
@@ -472,8 +472,8 @@ end);
 ## #I  SCIsKStackedSphere: complex is a 1-stacked sphere.
 ## #I  SCIsTight: complex is 3-dimensional, 2-neighbourly, and stacked, and thus tight.
 ## true
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> list:=SCLib.SearchByName("S^3xS^1");;
 ## gap> c:=SCLib.Load(list[1][1]);           
 ## gap> SCInfoLevel(0);
@@ -493,7 +493,7 @@ end);
 ## 1-stacked.
 ## #I  SCIsTight: complex is in class K(1) and 2-neighborly, thus tight.
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>

--- a/lib/normalsurface.gi
+++ b/lib/normalsurface.gi
@@ -57,7 +57,7 @@ end;
 ## <Returns>the discrete normal surface passed as argument upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Positively shifts the vertex labels of <Arg>complex</Arg> (provided that all labels satisfy the property <C>IsAdditiveElement</C>) by the amount specified in <Arg>value</Arg>.
-## <Example>
+## <Example><![CDATA[
 ## gap> sl:=SCNSSlicing(SCBdSimplex(4),[[1],[2..5]]);;
 ## gap> sl.Facets;                                    
 ## [ [ [ 1, 2 ], [ 1, 3 ], [ 1, 4 ] ], [ [ 1, 2 ], [ 1, 3 ], [ 1, 5 ] ], 
@@ -66,7 +66,7 @@ end;
 ## gap> sl.Facets;  
 ## [ [ [ 3, 4 ], [ 3, 5 ], [ 3, 6 ] ], [ [ 3, 4 ], [ 3, 5 ], [ 3, 7 ] ], 
 ##   [ [ 3, 4 ], [ 3, 6 ], [ 3, 7 ] ], [ [ 3, 5 ], [ 3, 6 ], [ 3, 7 ] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -85,7 +85,7 @@ end);
 ## <Returns>the discrete normal surface passed as argument upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Negatively shifts the vertex labels of <Arg>complex</Arg> (provided that all labels satisfy the property <C>IsAdditiveElement</C>) by the amount specified in <Arg>value</Arg>.
-## <Example>
+## <Example><![CDATA[
 ## gap> sl:=SCNSSlicing(SCBdSimplex(4),[[1],[2..5]]);;
 ## gap> sl.Facets;                                    
 ## [ [ [ 1, 2 ], [ 1, 3 ], [ 1, 4 ] ], [ [ 1, 2 ], [ 1, 3 ], [ 1, 5 ] ], 
@@ -94,7 +94,7 @@ end);
 ## gap> sl.Facets;  
 ## [ [ [ -1, 0 ], [ -1, 1 ], [ -1, 2 ] ], [ [ -1, 0 ], [ -1, 1 ], [ -1, 3 ] ], 
 ##   [ [ -1, 0 ], [ -1, 2 ], [ -1, 3 ] ], [ [ -1, 1 ], [ -1, 2 ], [ -1, 3 ] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -113,7 +113,7 @@ end);
 ## <Returns>the discrete normal surface passed as argument upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Multiplies the vertex labels of <Arg>complex</Arg> (provided that all labels satisfy the property <C>IsAdditiveElement</C>) with the integer specified in <Arg>value</Arg>.
-## <Example>
+## <Example><![CDATA[
 ## gap> sl:=SCNSSlicing(SCBdSimplex(4),[[1],[2..5]]);;
 ## gap> sl.Facets;                                    
 ## [ [ [ 1, 2 ], [ 1, 3 ], [ 1, 4 ] ], [ [ 1, 2 ], [ 1, 3 ], [ 1, 5 ] ], 
@@ -122,7 +122,7 @@ end);
 ## gap> sl.Facets;  
 ## [ [ [ 2, 4 ], [ 2, 6 ], [ 2, 8 ] ], [ [ 2, 4 ], [ 2, 6 ], [ 2, 10 ] ], 
 ##   [ [ 2, 4 ], [ 2, 8 ], [ 2, 10 ] ], [ [ 2, 6 ], [ 2, 8 ], [ 2, 10 ] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -141,7 +141,7 @@ end);
 ## <Returns>the discrete normal surface passed as argument upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Takes all vertex labels of <Arg>complex</Arg> modulo the value specified in <Arg>value</Arg> (provided that all labels satisfy the property <C>IsAdditiveElement</C>). Warning: this might result in different vertices being assigned the same label or even invalid facet lists, so be careful.
-## <Example>
+## <Example><![CDATA[
 ## gap> sl:=SCNSSlicing(SCBdSimplex(4),[[1],[2..5]]);;    
 ## gap> sl.Facets;
 ## [ [ [ 1, 2 ], [ 1, 3 ], [ 1, 4 ] ], [ [ 1, 2 ], [ 1, 3 ], [ 1, 5 ] ], 
@@ -150,7 +150,7 @@ end);
 ## gap> sl.Facets;    
 ## [ [ [ 1, 0 ], [ 1, 1 ], [ 1, 0 ] ], [ [ 1, 0 ], [ 1, 1 ], [ 1, 1 ] ], 
 ##   [ [ 1, 0 ], [ 1, 0 ], [ 1, 1 ] ], [ [ 1, 1 ], [ 1, 0 ], [ 1, 1 ] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -169,7 +169,7 @@ end);
 ## <Returns>discrete normal surface of type <C>SCNormalSurface</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the union of two discrete normal surfaces by calling <Ref Meth="SCUnion"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByAttribute("F = [ 10, 35, 50, 25 ]");
 ## [ [ 19, "S^3 (VT)" ] ]
 ## gap> c:=SCLib.Load(last[1][1]);;
@@ -180,7 +180,7 @@ end);
 ## gap> sl3:=Union(sl1,sl2);;
 ## gap> SCTopologicalType(sl3);
 ## "T^2 U T^2"
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -290,7 +290,7 @@ end;
 ## <Returns>discrete normal surface of type <C>SCNormalSurface</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Constructor for a discrete normal surface from a facet list, see <Ref Meth="SCFromFacets"/> for details.
-## <Example>
+## <Example><![CDATA[
 ## gap> sl:=SCNSFromFacets([[1,2,3],[1,2,4,5],[1,3,4,6],[2,3,5,6],[4,5,6]]);
 ## [NormalSurface
 ## 
@@ -300,7 +300,7 @@ end;
 ##  Dim=2
 ## 
 ## /NormalSurface]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -354,7 +354,7 @@ end);
 ## <Returns>discrete normal surface of type <C>SCNormalSurface</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Internally calls <Ref Meth="SCNSFromFacets"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> sl:=SCNS([[1,2,3],[1,2,4,5],[1,3,4,6],[2,3,5,6],[4,5,6]]);
 ## [NormalSurface
 ## 
@@ -364,7 +364,7 @@ end);
 ##  Dim=2
 ## 
 ## /NormalSurface]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -400,7 +400,7 @@ end);
 ## <Returns>discrete normal surface of type <C>SCNormalSurface</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Copies a &GAP; object of type <C>SCNormalSurface</C> (cf. <Ref Meth="SCCopy"/>).
-## <Example>
+## <Example><![CDATA[
 ## gap> sl:=SCNSSlicing(SCBdSimplex(4),[[1],[2..5]]);
 ## [NormalSurface
 ## 
@@ -431,7 +431,7 @@ end);
 ## /NormalSurface]
 ## gap> IsIdenticalObj(sl,sl_2);                     
 ## false
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -490,7 +490,7 @@ end);
 ## <Returns>discrete normal surface of type <C>SCNormalSurface</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Generates an empty complex (of dimension <M>-1</M>), i. e. an object of type <C>SCNormalSurface</C> with empty facet list.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCNSEmpty();
 ## [NormalSurface
 ## 
@@ -500,7 +500,7 @@ end);
 ##  Dim=-1
 ## 
 ## /NormalSurface]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -526,14 +526,14 @@ end);
 ## <Returns>an integer upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the dimension of a discrete normal surface (which is always <M>2</M> if the slicing <Arg>sl</Arg> is not empty).
-## <Example>
+## <Example><![CDATA[
 ## gap> sl:=SCNSEmpty();;                                                    
 ## gap> SCDim(sl);                                                         
 ## -1
 ## gap> sl:=SCNSFromFacets([[1,2,3],[1,2,4,5],[1,3,4,6],[2,3,5,6],[4,5,6]]);;
 ## gap> SCDim(sl);                                                         
 ## 2
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -558,13 +558,13 @@ end);
 ## <Returns>a <M>1</M>, <M>3</M> or <M>4</M> tuple of (non-negative) integer values upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the <M>f</M>-vector of a discrete normal surface, i. e. the number of vertices, edges, triangles and quadrilaterals of <Arg>sl</Arg>, cf. <Ref Meth="SCFVector"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> list:=SCLib.SearchByName("S^2xS^1");;
 ## gap> c:=SCLib.Load(list[1][1]);;             
 ## gap> sl:=SCNSSlicing(c,[[1..5],[6..10]]);;
 ## gap> SCFVector(sl);                 
 ## [ 20, 40, 16, 8 ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -613,13 +613,13 @@ end);
 ## <Returns>an integer upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the Euler characteristic of a discrete normal surface <Arg>sl</Arg>, cf. <Ref Meth="SCEulerCharacteristic"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> list:=SCLib.SearchByName("S^2xS^1");;  
 ## gap> c:=SCLib.Load(list[1][1]);;             
 ## gap> sl:=SCNSSlicing(c,[[1..5],[6..10]]);;
 ## gap> SCEulerCharacteristic(sl);                 
 ## 4
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -658,7 +658,7 @@ end);
 ## <Returns>a non-negative integer upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the genus of a discrete normal surface <Arg>sl</Arg>.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("(S^2xS^1)#20");
 ## [ [ 633, "(S^2xS^1)#20" ] ]
 ## gap> c:=SCLib.Load(last[1][1]);;               
@@ -669,7 +669,7 @@ end);
 ## true
 ## gap> SCGenus(sl);                     
 ## 7
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -703,10 +703,10 @@ end);
 ## <Returns><K>true</K> or <K>false</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Checks if a normal surface <Arg>complex</Arg> is the empty complex, i. e. a <C>SCNormalSurface</C> object with empty facet list.
-## <Example>
+## <Example><![CDATA[
 ## gap> sl:=SCNS([]);;
 ## gap> SCIsEmpty(sl);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -738,14 +738,14 @@ end);
 ## <Returns>normal surface of type <C>SCNormalSurface</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Forms the union of two normal surfaces <Arg>complex1</Arg> and <Arg>complex2</Arg> as the normal surface formed by the union of their facet sets. The two arguments are not altered. Note: for the union process the vertex labelings of the complexes are taken into account, see also <Ref Meth="Operation Union (SCNormalSurface, SCNormalSurface)" />. Facets occurring in both arguments are treated as one facet in the new complex.
-## <Example>
+## <Example><![CDATA[
 ## gap> list:=SCLib.SearchByAttribute("Dim=3 and F[1]=10");;
 ## gap> c:=SCLib.Load(list[1][1]);
 ## gap> sl1:=SCNSSlicing(c,[[1..5],[6..10]]);;
 ## gap> sl2:=sl1+10;;
 ## gap> sl3:=SCUnion(sl1,sl2);;
 ## gap> SCTopologicalType(sl3);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -791,12 +791,12 @@ end);
 ## <Returns><K>true</K> or <K>false</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Checks if a normal surface <Arg>complex</Arg> is connected.
-## <Example>
+## <Example><![CDATA[
 ## gap> list:=SCLib.SearchByAttribute("Dim=3 and F[1]=10");;
 ## gap> c:=SCLib.Load(list[1][1]);
 ## gap> sl:=SCNSSlicing(c,[[1..5],[6..10]]);
 ## gap> SCIsConnected(sl);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -848,10 +848,10 @@ end);
 ## <Returns> a list of simplicial complexes of type <C>SCNormalSurface</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes all connected components of an arbitrary normal surface.
-## <Example>
+## <Example><![CDATA[
 ## gap> sl:=SCNSSlicing(SCBdCrossPolytope(4),[[1,2],[3..8]]);
 ## gap> cc:=SCConnectedComponents(sl);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>                                         
@@ -922,13 +922,13 @@ end);
 ## Computes all faces of cardinality <Arg>k+1</Arg> in the standard labeling: <Arg>k</Arg> <M>= 0</M> computes the vertices,  <Arg>k</Arg> <M>= 1</M> computes the edges,  <Arg>k</Arg> <M>= 2</M> computes the triangles,  <Arg>k</Arg> <M>= 3</M> computes the quadrilaterals.<P/>
 ## 
 ## If <Arg>k</Arg> is a list (necessarily a sublist of <C>[ 0,1,2,3 ]</C>) all faces of all cardinalities contained in <Arg>k</Arg> are computed.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(4);;              
 ## gap> sl:=SCNSSlicing(c,[[1],[2..5]]);;
 ## gap> SCSkelEx(sl,1);                            
 ## [ [ 1, 2 ], [ 1, 3 ], [ 1, 4 ], [ 2, 3 ], [ 2, 4 ], [ 3, 4 ] ]
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(4);;              
 ## gap> sl:=SCNSSlicing(c,[[1],[2..5]]);;
 ## gap> SCSkelEx(sl,3);                            
@@ -936,7 +936,7 @@ end);
 ## gap> sl:=SCNSSlicing(c,[[1,2],[3..5]]);;
 ## gap> SCSkelEx(sl,3);                            
 ## [ [ 1, 2, 4, 5 ], [ 1, 3, 4, 6 ], [ 2, 3, 5, 6 ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -994,14 +994,14 @@ end);
 ## Computes all faces of cardinality <Arg>k+1</Arg> in the original labeling: <Arg>k</Arg> <M>= 0</M> computes the vertices,  <Arg>k</Arg> <M>= 1</M> computes the edges,  <Arg>k</Arg> <M>= 2</M> computes the triangles,  <Arg>k</Arg> <M>= 3</M> computes the quadrilaterals.<P/>
 ## 
 ## If <Arg>k</Arg> is a list (necessarily a sublist of <C>[ 0,1,2,3 ]</C>) all faces of all cardinalities contained in <Arg>k</Arg> are computed.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(4);;              
 ## gap> sl:=SCNSSlicing(c,[[1],[2..5]]);;
 ## gap> SCSkel(sl,1);                            
 ## [ [ [ 1, 2 ], [ 1, 3 ] ], [ [ 1, 2 ], [ 1, 4 ] ], [ [ 1, 2 ], [ 1, 5 ] ], 
 ##   [ [ 1, 3 ], [ 1, 4 ] ], [ [ 1, 3 ], [ 1, 5 ] ], [ [ 1, 4 ], [ 1, 5 ] ] ]
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(4);;              
 ## gap> sl:=SCNSSlicing(c,[[1],[2..5]]);;
 ## gap> SCSkel(sl,3);                            
@@ -1011,7 +1011,7 @@ end);
 ## [ [ [ 1, 3 ], [ 1, 4 ], [ 2, 3 ], [ 2, 4 ] ], 
 ##   [ [ 1, 3 ], [ 1, 5 ], [ 2, 3 ], [ 2, 5 ] ], 
 ##   [ [ 1, 4 ], [ 1, 5 ], [ 2, 4 ], [ 2, 5 ] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1047,7 +1047,7 @@ end);
 ## <Returns>a list of face lists upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the face lattice of a discrete normal surface <Arg>sl</Arg> in the standard labeling. Triangles and quadrilaterals are stored separately (cf. <Ref Meth="SCSkelEx" />).
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(4);;              
 ## gap> sl:=SCNSSlicing(c,[[1,2],[3..5]]);;
 ## gap> SCFaceLatticeEx(sl);                            
@@ -1058,7 +1058,7 @@ end);
 ##   [ [ 1, 2, 4, 5 ], [ 1, 3, 4, 6 ], [ 2, 3, 5, 6 ] ] ]
 ## gap> sl.F;
 ## [ 6, 9, 2, 3 ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1096,7 +1096,7 @@ end);
 ## <Returns>a list of facet lists upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the face lattice of a discrete normal surface <Arg>sl</Arg> in the original labeling. Triangles and quadrilaterals are stored separately (cf. <Ref Meth="SCSkel" />).
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(4);;              
 ## gap> sl:=SCNSSlicing(c,[[1,2],[3..5]]);;
 ## gap> SCFaceLattice(sl);                            
@@ -1111,7 +1111,7 @@ end);
 ##     [ [ 1, 4 ], [ 1, 5 ], [ 2, 4 ], [ 2, 5 ] ] ] ]
 ## gap> sl.F;
 ## [ 6, 9, 2, 3 ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1144,7 +1144,7 @@ end);
 ## <Returns>simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes a simplicial subdivision of a slicing <Arg>sl</Arg> without introducing new vertices. The subdivision is stored as a property of <Arg>sl</Arg> and thus is returned as an immutable object. Note that symmetry may be lost during the computation. 
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByAttribute("F=[ 10, 35, 50, 25 ]");
 ## [ [ 19, "S^3 (VT)" ] ]
 ## gap> c:=SCLib.Load(last[1][1]);;
@@ -1154,7 +1154,7 @@ end);
 ## gap> sc:=SCNSTriangulation(sl);;
 ## gap> sc.F;
 ## [ 9, 27, 18 ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1198,7 +1198,7 @@ end);
 ## <Returns>a list of homology groups upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the homology of a slicing <Arg>sl</Arg>. Internally, <Arg>sl</Arg> is triangulated (cf. <Ref Meth="SCNSTriangulation"/>) and simplicial homology is computed via <Ref Meth="SCHomology"/> using the triangulation.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("(S^2xS^1)#20");       
 ## [ [ 633, "(S^2xS^1)#20" ] ]
 ## gap> c:=SCLib.Load(last[1][1]);;
@@ -1210,7 +1210,7 @@ end);
 ## gap> sl:=SCNSSlicing(c,[[1..13],[14..27]]);;
 ## gap> sl.Homology;                       
 ## [ [ 1, [  ] ], [ 14, [  ] ], [ 2, [  ] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1238,7 +1238,7 @@ end);
 ## <Returns>a list of non-negative integers upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the Betti numbers modulo <Arg>p</Arg> of a slicing <Arg>sl</Arg>. Internally, <Arg>sl</Arg> is triangulated (using <Ref Meth="SCNSTriangulation"/>) and the Betti numbers are computed via <Ref Meth="SCFpBettiNumbers"/> using the triangulation.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("(S^2xS^1)#20");       
 ## [ [ 633, "(S^2xS^1)#20" ] ]
 ## gap> c:=SCLib.Load(last[1][1]);;
@@ -1247,7 +1247,7 @@ end);
 ## gap> sl:=SCNSSlicing(c,[[1..13],[14..27]]);;
 ## gap> SCFpBettiNumbers(sl,2);
 ## [ 2, 14, 2 ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1299,7 +1299,7 @@ end);
 ## <Returns>a string upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Determines the topological type of <Arg>sl</Arg> via the classification theorem for closed compact surfaces. If <Arg>sl</Arg> is not connected, the topological type of each connected component is computed.<P/>
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("(S^2xS^1)#20");      
 ## [ [ 633, "(S^2xS^1)#20" ] ]
 ## gap> c:=SCLib.Load(last[1][1]);;
@@ -1332,7 +1332,7 @@ end);
 ## T^2
 ## S^2
 ## S^2
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1446,12 +1446,12 @@ end);
 ## <Returns><K>true</K> or <K>false</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Checks if a discrete normal surface <Arg>sl</Arg> is orientable.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(4);;
 ## gap> sl:=SCNSSlicing(c,[[1,2],[3,4,5]]);
 ## gap> SCIsOrientable(sl);
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1491,7 +1491,7 @@ end);
 ## <Returns>discrete normal surface of type <C>SCNormalSurface</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes a slicing defined by a partition <Arg>slicing</Arg> of the set of vertices of the <M>3</M>-dimensional combinatorial pseudomanifold  <Arg>complex</Arg>. In particular, <Arg>slicing</Arg> has to be a pair of lists of vertex labels and has to contain all vertex labels of <Arg>complex</Arg>.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByAttribute("F=[ 10, 35, 50, 25 ]");
 ## [ [ 19, "S^3 (VT)" ] ]
 ## gap> c:=SCLib.Load(last[1][1]);;                       
@@ -1543,7 +1543,7 @@ end);
 ##   [ [ 3, 2 ], [ 3, 4 ], [ 5, 2 ], [ 5, 4 ] ], 
 ##   [ [ 3, 2 ], [ 3, 6 ], [ 5, 2 ], [ 5, 6 ] ], 
 ##   [ [ 3, 4 ], [ 3, 6 ], [ 5, 4 ], [ 5, 6 ] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>

--- a/lib/operations.gi
+++ b/lib/operations.gi
@@ -82,7 +82,7 @@ end;
 ## <Returns>simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Calculates the simplicial join of the simplicial complexes <Arg>complex1</Arg> and <Arg>complex2</Arg>. If facet lists instead of <C>SCSimplicialComplex</C> objects are passed as arguments, the function internally falls back to the homology package <Cite Key="Dumas04Homology" />, if available. Note that the vertex labelings of the complexes passed as arguments are not propagated to the new complex.
-## <Example>
+## <Example><![CDATA[
 ## gap> sphere:=SCJoin(SCBdSimplex(2),SCBdSimplex(2));
 ## gap> SCHasBoundary(sphere);
 ## false
@@ -98,15 +98,15 @@ end;
 ##   [ [ 1, 2 ], [ 1, 3 ], [ 2, 2 ], [ 2, 3 ] ] ]
 ## gap> sphere.Homology;
 ## [ [ 0, [  ] ], [ 0, [  ] ], [ 0, [  ] ], [ 1, [  ] ] ]
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> ball:=SCJoin(SC([[1]]),SCBdSimplex(2));
 ## gap> ball.Homology;
 ## [ [ 0, [  ] ], [ 0, [  ] ], [ 0, [  ] ] ]
 ## gap> ball.Facets;
 ## [ [ [ 1, 1 ], [ 2, 1 ], [ 2, 2 ] ], [ [ 1, 1 ], [ 2, 1 ], [ 2, 3 ] ],
 ##   [ [ 1, 1 ], [ 2, 2 ], [ 2, 3 ] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -152,12 +152,12 @@ end);
 ## <Returns>simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Calculates the simplicial suspension of the simplicial complex <Arg>complex</Arg>. Internally falls back to the homology package <Cite Key="Dumas04Homology" /> (if available) if a facet list is passed as argument. Note that the vertex labelings of the complexes passed as arguments are not propagated to the new complex.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("Poincare");
 ## gap> phs:=SCLib.Load(last[1][1]);
 ## gap> susp:=SCSuspension(phs);;
 ## gap> edwardsSphere:=SCSuspension(susp);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -206,7 +206,7 @@ end);
 ## <Returns>simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Calculates the simplicial deleted join of the simplicial complexes <Arg>complex1</Arg> and <Arg>complex2</Arg>. If called with a facet list instead of a <C>SCSimplicialComplex</C> object, the function internally falls back to the <Package>homology</Package> package <Cite Key="Dumas04Homology" />, if available.
-## <Example>
+## <Example><![CDATA[
 ## gap> deljoin:=SCDeletedJoin(SCBdSimplex(3),SCBdSimplex(3));
 ## gap> bddeljoin:=SCBoundary(deljoin);;
 ## gap> bddeljoin.Homology;
@@ -226,7 +226,7 @@ end);
 ##   [ [ 1, 2 ], [ 2, 2 ], [ 3, 1 ], [ 4, 1 ] ],
 ##   [ [ 1, 2 ], [ 2, 2 ], [ 3, 1 ], [ 4, 2 ] ],
 ##   [ [ 1, 2 ], [ 2, 2 ], [ 3, 2 ], [ 4, 1 ] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -304,12 +304,12 @@ end);
 ## <Returns>simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Calculates the wedge product of the complexes supplied as arguments. Note that the vertex labelings of the complexes passed as arguments are not propagated to the new complex.
-## <Example>
+## <Example><![CDATA[
 ## gap> wedge:=SCWedge(SCBdSimplex(2),SCBdSimplex(2));
 ## gap> wedge.Facets;
 ## [ [ [ 1, 2 ], [ 1, 3 ] ], [ [ 2, 2 ], [ 2, 3 ] ], [ [ 1, 2 ], "a" ], 
 ##   [ [ 1, 3 ], "a" ], [ [ 2, 2 ], "a" ], [ [ 2, 3 ], "a" ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -418,7 +418,7 @@ end;
 ## <Returns>simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Forms the ``difference'' of two simplicial complexes <Arg>complex1</Arg> and <Arg>complex2</Arg> as the simplicial complex formed by the difference of the face lattices of <Arg>complex1</Arg> minus <Arg>complex2</Arg>. The two arguments are not altered. Note: for the difference process the vertex labelings of the complexes are taken into account, see also <Ref Meth="Operation Difference (SCSimplicialComplex, SCSimplicialComplex)"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(3);;
 ## gap> d:=SC([[1,2,3]]);;
 ## gap> disc:=SCDifference(c,d);;
@@ -427,7 +427,7 @@ end;
 ## gap> empty:=SCDifference(d,c);;
 ## gap> empty.Dim;
 ## -1
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -467,13 +467,13 @@ end);
 ## <Returns>a list of faces upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## In a simplicial complex <Arg>complex</Arg> all neighbors of the <C>k</C>-face  <Arg>face</Arg>, i. e. all <C>k</C>-faces distinct from <Arg>face</Arg> intersecting with <Arg>face</Arg> in a common <M>(k-1)</M>-face, are returned in the standard labeling.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCFromFacets(Combinations(["a","b","c"],2));
 ## gap> SCLabels(c);
 ## [ "a", "b", "c" ]
 ## gap> SCNeighborsEx(c,[1,2]);
 ## [ [ 1, 3 ], [ 2, 3 ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -524,11 +524,11 @@ end);
 ## <Returns>a list of faces upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## In a simplicial complex <Arg>complex</Arg> all neighbors of the <C>k</C>-face  <Arg>face</Arg>, i. e. all <C>k</C>-faces distinct from <Arg>face</Arg> intersecting with <Arg>face</Arg> in a common <M>(k-1)</M>-face, are returned in the original labeling.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCFromFacets(Combinations(["a","b","c"],2));
 ## gap> SCNeighbors(c,["a","d"]);
 ## [ [ "a", "b" ], [ "a", "c" ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -580,7 +580,7 @@ end);
 ## <Returns>simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Forms the ``intersection'' of two simplicial complexes <Arg>complex1</Arg> and <Arg>complex2</Arg> as the simplicial complex formed by the intersection of the face lattices of <Arg>complex1</Arg> and <Arg>complex2</Arg>. The two arguments are not altered. Note: for the intersection process the vertex labelings of the complexes are taken into account. See also <Ref Meth="Operation Intersection (SCSimplicialComplex, SCSimplicialComplex)"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(3);;        
 ## gap> d:=SCBdSimplex(3)+1;;      
 ## gap> d.Facets;
@@ -591,7 +591,7 @@ end);
 ## gap> s1:=SCIntersection(c,d);;
 ## gap> s1.Facets;               
 ## [ [ 2, 3 ], [ 2, 4 ], [ 3, 4 ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -631,9 +631,9 @@ end);
 ## <Returns>simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Forms the union of two simplicial complexes <Arg>complex1</Arg> and <Arg>complex2</Arg> as the simplicial complex formed by the union of their facets sets. The two arguments are not altered. Note: for the union process the vertex labelings of the complexes are taken into account, see also <Ref Meth="Operation Union (SCSimplicialComplex, SCSimplicialComplex)" />. Facets occurring in both arguments are treated as one facet in the new complex.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCUnion(SCBdSimplex(3),SCBdSimplex(3)+3); #a wedge of two 2-spheres
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -680,7 +680,7 @@ end);
 ## <Returns><K>true</K> or <K>false</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Returns <K>true</K> if the simplicial complex <Arg>sc2</Arg> is a sub-complex of simplicial complex <Arg>sc1</Arg>, <K>false</K> otherwise. If dim(<Arg>sc2</Arg>) <M>\leq</M> dim(<Arg>sc1</Arg>) the facets of <Arg>sc2</Arg> are compared with the dim(<Arg>sc2</Arg>)-skeleton of <Arg>sc1</Arg>. Only works for pure simplicial complexes. Note: for the intersection process the vertex labelings of the complexes are taken into account. 
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByAttribute("F[1]=10"){[1..10]};
 ## [ [ 17, "T^2 (VT)" ], [ 18, "K^2 (VT)" ], 
 ##   [ 19, "S^3 (VT)" ], [ 20, "(T^2)#2" ], [ 21, "S^3 (VT)" ],
@@ -697,7 +697,7 @@ end);
 ## true
 ## gap> SCIsSubcomplex(k,c);
 ## false
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -736,7 +736,7 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## The Alexander dual of a simplicial complex <Arg>complex</Arg> with set of vertices <M>V</M> is the simplicial complex where any subset of <M>V</M> spans a face if and only if its complement in <M>V</M> is a non-face of <Arg>complex</Arg>.
-## <Example>
+## <Example><![CDATA[
 ## # a square
 ## gap> c:=SC([[1,2],[2,3],[3,4],[4,1]]);;
 ## gap> dual:=SCAlexanderDual(c);;
@@ -746,7 +746,7 @@ end);
 ## false
 ## gap> dual.Facets;
 ## [[1, 3], [2, 4]]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -843,7 +843,7 @@ end;
 ## <Returns>simplicial complex of type <C>SCSimplicialComplex</C>, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Returns a simplicial complex obtained by identifying the vertices of facet <Arg>f1</Arg> with the ones from facet <Arg>f2</Arg> in <Arg>complex</Arg>. A combinatorial handle addition is possible, whenever we have d<M>(v,w) \geq 3</M> for any two vertices <M>v \in </M><Arg>f1</Arg> and <M>w \in </M><Arg>f2</Arg>, where d<M>(\cdot,\cdot)</M> is the length of the shortest path from <M>v</M> to <M>w</M>. This condition is not checked by this algorithm. See <Cite Key="Bagchi08OnWalkupKd"/> for further information.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SC([[1,2,4],[2,4,5],[2,3,5],[3,5,6],[1,3,6],[1,4,6]]);;
 ## gap> c:=SCUnion(c,SCUnion(SCCopy(c)+3,SCCopy(c)+6));;
 ## gap> c:=SCUnion(c,SC([[1,2,3],[10,11,12]]));;
@@ -860,7 +860,7 @@ end;
 ## gap> ism:=SCIsManifold(torus);;
 ## gap> ism;
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -905,14 +905,14 @@ end);
 ## <Returns>simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Identifies vertex <Arg>v1</Arg> with vertex <Arg>v2</Arg> in a simplicial complex <Arg>complex</Arg> and returns the result as a new object. A vertex identification of <Arg>v1</Arg> and <Arg>v2</Arg> is possible whenever d(<Arg>v1</Arg>,<Arg>v2</Arg>) <M>\geq 3</M>. This is not checked by this algorithm. 
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SC([[1,2],[2,3],[3,4]]);;
 ## gap> circle:=SCVertexIdentification(c,[1],[4]);;
 ## gap> circle.Facets;
 ## [[1, 2], [1, 3], [2, 3]]
 ## gap> circle.Homology;
 ## [[0, []], [1, []]]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -953,13 +953,13 @@ end);
 ## <Returns> a list of simplicial complexes of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the link of all <Arg>k</Arg>-faces of the polyhedral complex <Arg>complex</Arg> and returns them as a list of simplicial complexes. Internally calls <Ref Meth="SCLink"/> for every <Arg>k</Arg>-face of <Arg>complex</Arg>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(4);;
 ## # all vertex links -> 2 spheres
 ## gap> SCLinks(c,0);
 ## # all edge links -> circles
 ## gap> SCLinks(c,1);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -998,13 +998,13 @@ end);
 ## <Returns> a list of simplicial complexes of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the star of all <Arg>k</Arg>-faces of the polyhedral complex <Arg>complex</Arg> and returns them as a list of simplicial complexes. Internally calls <Ref Meth="SCStar"/> for every <Arg>k</Arg>-face of <Arg>complex</Arg>.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("T^2"){[1..6]};
 ## [ [ 4, "T^2 (VT)" ], [ 5, "T^2 (VT)" ], [ 9, "T^2 (VT)" ], 
 ##   [ 10, "T^2 (VT)" ], [ 17, "T^2 (VT)" ], [ 20, "(T^2)#2" ] ]
 ## gap> torus:=SCLib.Load(last[1][1]);; # the minimal 7-vertex torus
 ## gap> SCStars(torus,0); # 7 2-discs as vertex stars
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1043,7 +1043,7 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the link of <Arg>face</Arg> (a face given as a list of vertices or a scalar interpreted as vertex) in a polyhedral complex <Arg>complex</Arg>, i. e. all facets containing <Arg>face</Arg>, reduced by <Arg>face</Arg>. if <Arg>complex</Arg> is pure, the resulting complex is of dimension dim(<Arg>complex</Arg>) - dim(<Arg>face</Arg>) <M>-1</M>. If <Arg>face</Arg> is not a face of <Arg>complex</Arg> the empty complex is returned.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("RP^2");     
 ## [ [ 3, "RP^2 (VT)" ], [ 262, "RP^2xS^1" ] ]
 ## gap> rp2:=SCLib.Load(last[1][1]);;
@@ -1052,7 +1052,7 @@ end);
 ## gap> SCLink(rp2,[1]);
 ## gap> last.Facets;
 ## [[2, 3], [2, 6], [3, 5], [4, 5], [4, 6]]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1153,7 +1153,7 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise .</Returns>
 ## <Description>
 ## Computes the star of <Arg>face</Arg> (a face given as a list of vertices or a scalar interpreted as vertex) in a polyhedral complex <Arg>complex</Arg>, i. e. the set of facets of <Arg>complex</Arg> that contain <Arg>face</Arg>.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("RP^2");     
 ## [ [ 3, "RP^2 (VT)" ], [ 262, "RP^2xS^1" ] ]
 ## gap> rp2:=SCLib.Load(last[1][1]);;
@@ -1162,7 +1162,7 @@ end);
 ## gap> SCStar(rp2,1);
 ## gap> last.Facets;
 ## [ [1, 2, 3], [1, 2, 6], [1, 3, 5], [1, 4, 5], [1, 4, 6] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1248,7 +1248,7 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise .</Returns>
 ## <Description>
 ## Computes the anti star of <Arg>face</Arg> (a face given as a list of vertices or a scalar interpreted as vertex) in <Arg>complex</Arg>, i. e. the complement of <Arg>face</Arg> in <Arg>complex</Arg>.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("RP^2");     
 ## [ [ 3, "RP^2 (VT)" ], [ 262, "RP^2xS^1" ] ]
 ## gap> rp2:=SCLib.Load(last[1][1]);;
@@ -1257,7 +1257,7 @@ end);
 ## gap> SCAntiStar(rp2,1);
 ## gap> last.Facets;
 ## [ [ 2, 3, 4 ], [ 2, 4, 5 ], [ 2, 5, 6 ], [ 3, 4, 6 ], [ 3, 5, 6 ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1326,7 +1326,7 @@ end);
 ## <Description>
 ## Fills the given simplicial sphere <Arg>complex</Arg> by forming the suspension of the anti star of <Arg>vertex</Arg> over <Arg>vertex</Arg>. This is a triangulated <M>(d+1)</M>-ball with the boundary <Arg>complex</Arg>, see <Cite Key="Bagchi08LBTNormPseudoMnf" />. If the optional argument <Arg>vertex</Arg> is not supplied, the first vertex of <Arg>complex</Arg> is chosen.<P/>
 ## Note that it is not checked whether <Arg>complex</Arg> really is a simplicial sphere -- this has to be done by the user!
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("S^4");
 ## gap> s:=SCLib.Load(last[1][1]);;
 ## gap> filled:=SCFillSphere(s);
@@ -1334,7 +1334,7 @@ end);
 ## gap> SCCollapseGreedy(filled);
 ## gap> bd:=SCBoundary(filled);;
 ## gap> bd=s;
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1439,20 +1439,20 @@ end;
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Computes the reduced face lattice of all faces of a simplicial complex <Arg>complex</Arg> that are spanned by <Arg>subset</Arg>, a subset of the set of vertices of <Arg>complex</Arg>. 
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdCrossPolytope(4);;
 ## gap> SCVertices(c);
 ## [1, 2, 3, 4, 5, 6, 7, 8]
 ## gap> span:=SCSpan(c,[1,2,3,4]);
 ## gap> span.Facets;
 ## [[1, 3], [1, 4], [2, 3], [2, 4]]
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> c:=SC([[1,2],[1,4,5],[2,3,4]]);;
 ## gap> span:=SCSpan(c,[2,3,5]);
 ## gap> SCFacets(span);
 ## [[2, 3], [5]]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1501,14 +1501,14 @@ end);
 ## <Returns> a list of pairs of vertex labels or <K>false</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Returns an isomorphism of simplicial complex <Arg>complex1</Arg> to simplicial complex <Arg>complex2</Arg> in the standard labeling if they are combinatorially isomorphic, <K>false</K> otherwise. If the <M>f</M>-vector and the Altshuler-Steinberg determinant of <Arg>complex1</Arg> and <Arg>complex2</Arg> are equal, the internal function <C>SCIntFunc.SCComputeIsomorphismsEx(complex1,complex2,true)</C> is called.
-## <Example>
+## <Example><![CDATA[
 ## gap> c1:=SC([[11,12,13],[11,12,14],[11,13,14],[12,13,14]]);;
 ## gap> c2:=SCBdSimplex(3);;
 ## gap> SCIsomorphism(c1,c2);
 ## [ [ 11, 1 ], [ 12, 2 ], [ 13, 3 ], [ 14, 4 ] ]
 ## gap> SCIsomorphismEx(c1,c2);
 ## [ [ [ 1, 1 ], [ 2, 2 ], [ 3, 3 ], [ 4, 4 ] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1617,14 +1617,14 @@ end);
 ## <Returns> a list of pairs of vertex labels or <K>false</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Returns an isomorphism of simplicial complex <Arg>complex1</Arg> to simplicial complex <Arg>complex2</Arg> in the standard labeling if they are combinatorially isomorphic, <K>false</K> otherwise. Internally calls <Ref Meth="SCIsomorphismEx"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c1:=SC([[11,12,13],[11,12,14],[11,13,14],[12,13,14]]);;
 ## gap> c2:=SCBdSimplex(3);;
 ## gap> SCIsomorphism(c1,c2);
 ## [ [ 11, 1 ], [ 12, 2 ], [ 13, 3 ], [ 14, 4 ] ]
 ## gap> SCIsomorphismEx(c1,c2);
 ## [ [ [ 1, 1 ], [ 2, 2 ], [ 3, 3 ], [ 4, 4 ] ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1678,7 +1678,7 @@ end);
 ## <Returns><K>true</K> or <K>false</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## The function returns <K>true</K>, if the simplicial complexes <Arg>complex1</Arg> and <Arg>complex2</Arg> are combinatorially isomorphic, <K>false</K> if not.
-## <Example>
+## <Example><![CDATA[
 ## gap> c1:=SC([[11,12,13],[11,12,14],[11,13,14],[12,13,14]]);;
 ## gap> c2:=SCBdSimplex(3);;
 ## gap> SCIsIsomorphic(c1,c2);
@@ -1686,7 +1686,7 @@ end);
 ## gap> c3:=SCBdCrossPolytope(3);;
 ## gap> SCIsIsomorphic(c1,c3);
 ## false
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1741,7 +1741,7 @@ end);
 ## <Description>
 ## If the second argument is passed every facet of the simplicial complex <Arg>complex</Arg> is united with <Arg>apex</Arg>. If not, an arbitrary vertex label <M>v</M> is used (which is not a vertex of <Arg>complex</Arg>). In the first case the vertex labeling remains unchanged. In the second case the function returns the new complex in the standard vertex labeling from <M>1</M> to <M>n+1</M> and the apex of the cone is <M>n+1</M>.<P/>
 ## If called with a facet list instead of a <C>SCSimplicialComplex</C> object and <Arg>apex</Arg> is not specified, internally falls back to the homology package <Cite Key="Dumas04Homology" />, if available. 
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("RP^3");
 ## [ [ 45, "RP^3" ], [ 114, "RP^3=L(2,1) (VT)" ], 
 ##   [ 237, "(S^2xS^1)#RP^3" ], [ 238, "(S^2~S^1)#RP^3" ], 
@@ -1757,8 +1757,8 @@ end);
 ## gap> cone:=SCCone(rp3);;
 ## gap> cone.F;
 ## [12, 62, 131, 120, 40]
-## </Example>
-## <Example>
+## ]]></Example>
+## <Example><![CDATA[
 ## gap> s:=SCBdSimplex(4)+12;;
 ## gap> s.Facets;             
 ## [ [ 13, 14, 15, 16 ], [ 13, 14, 15, 17 ], [ 13, 14, 16, 17 ], 
@@ -1769,7 +1769,7 @@ end);
 ## gap> cc.Facets;
 ## [ [ 12, 13, 14, 15, 16 ], [ 12, 13, 14, 15, 17 ], [ 12, 13, 14, 16, 17 ], 
 ##   [ 12, 13, 15, 16, 17 ], [ 12, 14, 15, 16, 17 ] ]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1862,13 +1862,13 @@ end);
 ## <Returns> simplicial complex of type <C>SCSimplicialComplex</C> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Closes a simplicial complex <Arg>complex</Arg> by building a cone over its boundary. If <Arg>apex</Arg> is specified it is assigned to the apex of the cone and the original vertex labeling of <Arg>complex</Arg> is preserved, otherwise an arbitrary vertex label is chosen and <Arg>complex</Arg> is returned in the standard labeling. 
-## <Example>
+## <Example><![CDATA[
 ## gap> s:=SCSimplex(5);;                                       
 ## gap> b:=SCSimplex(5);;
 ## gap> s:=SCClose(b,13);;
 ## gap> SCIsIsomorphic(s,SCBdSimplex(6));                       
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -1936,7 +1936,7 @@ end);
 ## If <Arg>all</Arg> is set to <K>true</K> all possible shellings of <Arg>complex</Arg> are computed. If <Arg>all</Arg> is set to <K>false</K>, at most one shelling is computed.<P/>
 ## Every shelling is represented as a permuted version of the facet list of <Arg>complex</Arg>. The list <Arg>checkvector</Arg> encodes a shelling in a shorter form. It only contains the indices of the facets. If an order of indices is assigned to <Arg>checkvector</Arg> the function tests whether it is a valid shelling or not.<P/>
 ## See <Cite Key="Ziegler95LectPolytopes"/>, <Cite Key="Pachner87KonstrMethKombHomeo" /> to learn more about shellings.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SCBdSimplex(4);;
 ## gap> c:=SCDifference(c,SC([c.Facets[1]]));; # bounded version
 ## gap> all:=SCShellingExt(c,true,[]);;
@@ -1944,7 +1944,7 @@ end);
 ## gap> all[1];
 ## gap> all:=SCShellingExt(c,false,[]);
 ## gap> all:=SCShellingExt(c,true,[1..4]);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2222,11 +2222,11 @@ end);
 ## An ordering <M>(F_1, F_2, \ldots , F_r)</M> on the facet list of a simplicial complex is a shelling if and only if <M>F_i \cap (F_1 \cup \ldots \cup F_{i-1})</M> is a pure simplicial complex of dimension <M>d-1</M> for all <M>i = 1, \ldots , r</M>.<P/>
 ## The function checks whether <Arg>complex</Arg> is shellable or not. In the first case a permuted version of the facet list of <Arg>complex</Arg> is returned encoding a shelling of <Arg>complex</Arg>, otherwise <K>false</K> is returned.<P/>
 ## Internally calls <Ref Meth="SCShellingExt"/><C>(complex,false,[]);</C>. To learn more about shellings see <Cite Key="Ziegler95LectPolytopes"/>, <Cite Key="Pachner87KonstrMethKombHomeo"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SC([[1,2,3],[1,2,4],[1,3,4]]);;
 ## gap> SCShelling(c);
 ## [[1, 2, 3], [1, 2, 4], [1, 3, 4]]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -2256,7 +2256,7 @@ end);
 ## An ordering <M>(F_1, F_2, \ldots , F_r)</M> on the facet list of a simplicial complex is a shelling if and only if <M>F_i \cap (F_1 \cup \ldots \cup F_{i-1})</M> is a pure simplicial complex of dimension <M>d-1</M> for all <M>i = 1, \ldots , r</M>.<P/>
 ## The function checks whether <Arg>complex</Arg> is shellable or not. In the first case a list of permuted facet lists of <Arg>complex</Arg> is returned containing all possible shellings of <Arg>complex</Arg>, otherwise <K>false</K> is returned.<P/>
 ## Internally calls <Ref Meth="SCShellingExt"/><C>(complex,true,[]);</C>. To learn more about shellings see <Cite Key="Ziegler95LectPolytopes"/>, <Cite Key="Pachner87KonstrMethKombHomeo"/>.
-## <Example>
+## <Example><![CDATA[
 ## gap> c:=SC([[1,2,3],[1,2,4],[1,3,4]]);;
 ## gap> SCShellings(c);
 ## [[[1, 2, 3], [1, 2, 4], [1, 3, 4]],
@@ -2266,7 +2266,7 @@ end);
 ##   [[1, 2, 4], [1, 3, 4], [1, 2, 3]],
 ##   [[1, 3, 4], [1, 2, 4], [1, 2, 3]] 
 ##]
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>

--- a/lib/pkghomalg.gi
+++ b/lib/pkghomalg.gi
@@ -65,11 +65,11 @@ end;
 ## a value of <C>1</C> yields <M>\mathbb{Z}</M>-matrices and a value of 
 ## <C>q</C>, q a prime or a prime power, computes the 
 ## <M>\mathbb{F}_q</M>-matrices.<P/>
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("CP^2 (VT)");
 ## gap> c:=SCLib.Load(last[1][1]);;
 ## gap> SCHomalgBoundaryMatrices(c,0);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -140,11 +140,11 @@ end);
 ## a value of <C>1</C> yields <M>\mathbb{Z}</M>-matrices and a value of 
 ## <C>q</C>, q a prime or a prime power, computes the 
 ## <M>\mathbb{F}_q</M>-matrices.<P/>
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("CP^2 (VT)");
 ## gap> c:=SCLib.Load(last[1][1]);;
 ## gap> SCHomalgCoboundaryMatrices(c,0);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -215,11 +215,11 @@ end);
 ## Note that if you are interested not only in the ranks of the homology 
 ## groups, but rather their full structure, have a look at the function 
 ## <Ref Meth="SCHomalgHomologyBasis" />.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("K3");
 ## gap> c:=SCLib.Load(last[1][1]);;
 ## gap> SCHomalgHomology(c,0);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -280,11 +280,11 @@ end);
 ## Note that if you are only interested in the ranks of the homology groups, 
 ## then it is better to use the funtion <Ref Meth="SCHomalgHomology" /> 
 ## which is way faster.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("K3");
 ## gap> c:=SCLib.Load(last[1][1]);;
 ## gap> SCHomalgHomologyBasis(c,0);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -336,11 +336,11 @@ end);
 ## Note that if you are interested not only in the ranks of the cohomology 
 ## groups, but rather their full structure, have a look at the function 
 ## <Ref Meth="SCHomalgCohomologyBasis" />.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("K3");
 ## gap> c:=SCLib.Load(last[1][1]);;
 ## gap> SCHomalgCohomology(c,0);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -400,11 +400,11 @@ end);
 ## Note that if you are only interested in the ranks of the cohomology groups, 
 ## then it is better to use the funtion <Ref Meth="SCHomalgCohomology" /> 
 ## which is way faster.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCLib.SearchByName("K3");
 ## gap> c:=SCLib.Load(last[1][1]);;
 ## gap> SCHomalgCohomologyBasis(c,0);
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>

--- a/lib/tools.gd
+++ b/lib/tools.gd
@@ -23,11 +23,11 @@
 ## <Returns><K>true</K></Returns>
 ## <Description>
 ## Sets the logging verbosity of <Package>simpcomp</Package>. A level of <M>0</M> suppresses all output, a level of <M>1</M> lets <Package>simpcomp</Package> output normal running information, whereas levels of <M>2</M> and higher display verbose running information. Examples of functions using more verbose logging are bistellar flip-related functions. 
-## <Example>
+## <Example><![CDATA[
 ## gap> SCInfoLevel(3);
 ## gap> c:=SCBdCrossPolytope(3);;
 ## gap> SCReduceComplex(c); 
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ## </Section>

--- a/lib/tools.gi
+++ b/lib/tools.gi
@@ -188,10 +188,10 @@ end;
 ## <Returns><K>true</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Sets the minimal time interval in seconds that mail messages can be sent by <Package>simpcomp</Package>. This prevents a flooding of the specified email address with messages sent by <Package>simpcomp</Package>. Default is 3600, i.e. one hour. 
-## <Example>
+## <Example><![CDATA[
 ## gap> SCMailSetMinInterval(7200);
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -214,10 +214,10 @@ end);
 ## <Returns><K>true</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Sets the email address that should be used to send notification messages and enables the mail notification system by calling <Ref Func="SCMailSetEnabled" />(<K>true</K>).
-## <Example>
+## <Example><![CDATA[
 ## gap> SCMailSetAddress("johndoe@somehost");
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -239,12 +239,12 @@ end);
 ## <Returns><K>true</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Enables or disables the mail notification system of <Package>simpcomp</Package>. By default it is disabled. Returns <K>fail</K> if no email message was previously set with <Ref Func="SCMailSetAddress" />.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCMailSetAddress("johndoe@somehost"); #enables mail notification
 ## true
 ## gap> SCMailSetEnabled(false);
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -273,14 +273,14 @@ end);
 ## <Returns><K>true</K> when the message was sent, <K>false</K> if it was not send, <K>fail</K> upon an error.</Returns>
 ## <Description>
 ## Tries to send an email to the address specified by <Ref Func="SCMailSetAddress" /> using the Unix program <C>mail</C>. The optional parameter <Arg>starttime</Arg> specifies the starting time (as the integer Unix timestamp) a calculation was started (then the duration of the calculation is included in the email), the optional boolean parameter <Arg>forcesend</Arg> can be used to force the sending of an email, even if this violates the minimal email sending interval, see <Ref Func="SCMailSetMinInterval" />.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCMailSetAddress("johndoe@somehost"); #enables mail notification
 ## true
 ## gap> SCMailIsEnabled();
 ## true
 ## gap> SCMailSend("Hello, this is simpcomp.");
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -385,10 +385,10 @@ end);
 ## <Returns><K>true</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Tries to send a pending email of the <Package>simpcomp</Package> email notification system. Returns <K>true</K> on success or if there was no mail pending.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCMailSendPending();
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -416,10 +416,10 @@ end);
 ## <Returns><K>true</K> or <K>false</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Returns <K>true</K> when an email of the <Package>simpcomp</Package> email notification system is pending, <K>false</K> otherwise.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCMailIsPending();
 ## false
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -437,12 +437,12 @@ end);
 ## <Returns><K>true</K> or <K>false</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Returns <K>true</K> when the mail notification system of <Package>simpcomp</Package> is enabled, <K>false</K> otherwise. Default setting is <K>false</K>.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCMailSetAddress("johndoe@somehost"); #enables mail notification
 ## true
 ## gap> SCMailIsEnabled();
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -461,9 +461,9 @@ end);
 ## <Returns>nothing.</Returns>
 ## <Description>
 ## Clears a pending mail message.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCMailClearPending();
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>
@@ -595,12 +595,12 @@ end;
 ## <Returns><K>true</K> upon success, <K>fail</K> otherwise.</Returns>
 ## <Description>
 ## Test whether the package <Package>simpcomp</Package> is functional by calling <C>Test("GAPROOT/pkg/simpcomp/tst/simpcomp.tst",rec(compareFunction := "uptowhitespace"));</C>. The returned value of GAP4stones is a measure of your system performance and differs from system to system.
-## <Example>
+## <Example><![CDATA[
 ## gap> SCRunTest();
 ## + test simpcomp package, version 0.0.0
 ## + GAP4stones: 69988
 ## true
-## </Example>
+## ]]></Example>
 ## </Description>
 ## </ManSection>
 ##<#/GAPDoc>


### PR DESCRIPTION
This ensures things like < which have special meaning in HTML can be
used unquoted
