### PR TITLE
Avoid InstallValue on a non-plain object

### DIFF
--- a/lib/lib.gd
+++ b/lib/lib.gd
@@ -44,7 +44,7 @@
 
 DeclareCategory("SCIsLibRepository",SCIsPropertyObject);
 
-DeclareGlobalVariable("SCLib");
+SCLib := fail; # dummy value, will be redefined later
 
 DeclareGlobalFunction("SCLibAdd");
 DeclareGlobalFunction("SCLibAllComplexes");

--- a/read.g
+++ b/read.g
@@ -71,4 +71,5 @@ SCIntFunc.CheckExternalProgramsAvailability();
 ReadPackage("simpcomp", "lib/prophandler.gd");
 
 #load global library
-InstallValue(SCLib,SCIntFunc.SCLibGlobalInit());
+Unbind(SCLib); # remove dummy value from lib.gd
+BindGlobal("SCLib",SCIntFunc.SCLibGlobalInit());


### PR DESCRIPTION
InstallValue is a complex thing, it actually *clones* the value passed
to it, which is fragile if not a bit dangerous. We thus have been trying
to get away from that, with the goal of some day restricting it to
'plain' lists or records. Luckily in almost all applications, one can
replace it with BindGlobal plus perhaps a dummy initialization to avoid
syntax warnings about undefined globals (Since GAP 4.12, there is also a
nicer alternative to this in DeclareGlobaName, but of course this is not
an option if one wants to stay compatible with older GAP versions).
