### PR TITLE
Fix GRAPE support

### DIFF
--- a/init.g
+++ b/init.g
@@ -52,7 +52,7 @@ end;
 SCIntFunc.SetupGrape:=function()
 	local success;
 	success:=IsPackageMarkedForLoading("grape", ">=4.2");
-	if success=true and IsBoundGlobal("AutGroupGraph") and IsBoundGlobal("EdgeOrbitsGraph") and Filename(DirectoriesPackagePrograms("grape"),"dreadnautB")<>fail then
+	if success=true and IsBoundGlobal("AutGroupGraph") and IsBoundGlobal("EdgeOrbitsGraph") and Filename(DirectoriesPackagePrograms("grape"),"dreadnaut")<>fail then
 		return true;
 	else
 		return false;


### PR DESCRIPTION
GRAPE hasn't shipped with a dreadnautB executable since November 2022.